### PR TITLE
[Feature] Rename AutoLink library target to Lynxtron

### DIFF
--- a/src/packages/browser-demo/rspack.config.ts
+++ b/src/packages/browser-demo/rspack.config.ts
@@ -50,21 +50,17 @@ const desktopConfig = defineConfig({
     ],
   },
   plugins: [
+    pluginLynxtron({
+      isDev,
+      entry: path.resolve(__dirname, './dist/desktop'),
+      args: isDev ? ['--inspect=9222'] : [],
+    }),
     new rspack.CopyRspackPlugin({
       patterns: [
         { from: './package.json', to: 'package.json' },
         { from: './output/bundle/lynx/', to: '.' },
       ],
     }),
-    ...(isDev
-      ? [
-          pluginLynxtron({
-            isDev,
-            entry: path.resolve(__dirname, './dist/desktop'),
-            args: isDev ? ['--inspect=9222'] : [],
-          }),
-        ]
-      : []),
   ],
   externalsPresets: { node: true },
   externals: {

--- a/src/packages/browser-demo/src/main/desktop/main.ts
+++ b/src/packages/browser-demo/src/main/desktop/main.ts
@@ -1,10 +1,10 @@
 import { app, LynxWindow, dialog } from '@lynx-js/lynxtron';
 import { LYNX_BUNDLE_PATH } from './vendorPaths';
 import path from 'path';
-const cef_module = require('@lynx-js/cef-webview');
+const cefWebview = require('@lynx-js/cef-webview/lynxtron');
 
 app.whenReady().then(() => {
-  cef_module.setUp();
+  cefWebview.initialize();
 
   const w = new LynxWindow({
     width: 1400,

--- a/src/packages/cef-webview/README.md
+++ b/src/packages/cef-webview/README.md
@@ -15,12 +15,12 @@ npm install @lynx-js/cef-webview
 ## Usage
 
 Enable the Lynxtron autolink plugin in your application build. AutoLink requires
-`@lynx-js/cef-webview/node-api`, which loads the current platform's Node-API
+`@lynx-js/cef-webview/lynxtron`, which loads the current platform's Lynxtron
 addon so its static Lynx registrations run during startup. CEF itself is
 initialized only when you call `initialize()`.
 
 ```ts
-import cefWebview from '@lynx-js/cef-webview/node-api';
+import cefWebview from '@lynx-js/cef-webview/lynxtron';
 
 cefWebview.initialize();
 ```

--- a/src/packages/cef-webview/lynx.lib.json
+++ b/src/packages/cef-webview/lynx.lib.json
@@ -1,7 +1,7 @@
 {
   "platforms": {
-    "node-api": {
-      "path": "node-api"
+    "lynxtron": {
+      "path": "dist"
     }
   }
 }

--- a/src/packages/cef-webview/package.json
+++ b/src/packages/cef-webview/package.json
@@ -7,7 +7,7 @@
   "main": "index.cjs",
   "exports": {
     ".": "./index.cjs",
-    "./node-api": "./index.cjs",
+    "./lynxtron": "./index.cjs",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/src/packages/lynx-library-headers/README.md
+++ b/src/packages/lynx-library-headers/README.md
@@ -1,8 +1,8 @@
 # @lynx-js/lynx-library-headers
 
 Header package for Lynx embedder C/C++ API and weak N-API based native
-libraries. This package only provides headers; it does not scaffold, build, or
-register libraries.
+libraries. This package provides headers and CMake helpers; it does not
+scaffold, build, or register libraries.
 
 ## Usage
 
@@ -12,9 +12,21 @@ native target include directories:
 ```js
 const path = require('node:path');
 const headersRoot = path.dirname(
-  require.resolve('@lynx-js/lynx-library-headers/package.json'),
+  require.resolve('@lynx-js/lynx-library-headers/package.json')
 );
 ```
+
+For Windows Lynx native library builds, include the packaged CMake helper to
+resolve the host runtime import library used by the generated native target:
+
+```cmake
+include("${headersRoot}/cmake/lynx-library-headers.cmake")
+lynx_link_lynxtron_runtime(your_target)
+```
+
+The helper resolves the Windows import library from the runtime package
+installed with `@lynx-js/lynx-library-headers`. You can override discovery with
+`-DLYNXTRON_IMPORT_LIB=/path/to/lynxtron.dll.lib`.
 
 The published package contains:
 
@@ -25,8 +37,10 @@ The published package contains:
 - Lynx value C API headers required by the embedder C API.
 - `lynx_extension.h` and `lynx/extension.h` convenience wrapper headers.
 - `lynx/registration.h` for generic embedder static registration helpers.
+- `cmake/lynx-library-headers.cmake` for resolving Windows runtime import
+  libraries used by Lynx native library builds.
 
-Embedders and Lynxtron packages use static registration from the native library:
+Lynx native libraries use static registration from the native library:
 
 ```cpp
 #include <lynx/registration.h>
@@ -47,7 +61,7 @@ Use `LYNX_REGISTER_NATIVE_MODULE` for Lynx weak N-API native modules and
 both features should call both macros, keeping the native module and element
 registrations separate.
 
-Lynxtron loads matching native libraries through its autolink flow; loading the
-library is enough for these static registrations to run.
+A host runtime that loads the native library is enough for these static
+registrations to run.
 
 Run `npm run copy-headers` in this package when updating the source headers.

--- a/src/packages/lynx-library-headers/cmake/lynx-library-headers.cmake
+++ b/src/packages/lynx-library-headers/cmake/lynx-library-headers.cmake
@@ -1,0 +1,136 @@
+if(NOT COMMAND lynx_resolve_node_package)
+  function(lynx_resolve_node_package PACKAGE_NAME OUT_VAR)
+    if(NOT DEFINED NODE_EXECUTABLE)
+      find_program(NODE_EXECUTABLE NAMES node)
+    endif()
+
+    if(NOT NODE_EXECUTABLE)
+      message(FATAL_ERROR "Unable to find node. Install Node.js before configuring Lynx library targets.")
+    endif()
+
+    if(NOT DEFINED LYNX_LIBRARY_PACKAGE_ROOT)
+      set(LYNX_LIBRARY_PACKAGE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
+    endif()
+
+    execute_process(
+      COMMAND
+        "${NODE_EXECUTABLE}"
+        -p
+        "require('node:path').dirname(require.resolve('${PACKAGE_NAME}/package.json'))"
+      WORKING_DIRECTORY "${LYNX_LIBRARY_PACKAGE_ROOT}"
+      RESULT_VARIABLE NODE_PACKAGE_RESULT
+      OUTPUT_VARIABLE NODE_PACKAGE_ROOT
+      ERROR_VARIABLE NODE_PACKAGE_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(NOT NODE_PACKAGE_RESULT EQUAL 0 OR NOT NODE_PACKAGE_ROOT)
+      string(REPLACE "\n" " " NODE_PACKAGE_ERROR "${NODE_PACKAGE_ERROR}")
+      message(FATAL_ERROR "Unable to resolve ${PACKAGE_NAME}. Run npm install first. ${NODE_PACKAGE_ERROR}")
+    endif()
+
+    set(${OUT_VAR} "${NODE_PACKAGE_ROOT}" PARENT_SCOPE)
+  endfunction()
+endif()
+
+get_filename_component(
+  LYNX_LIBRARY_HEADERS_PACKAGE_ROOT
+  "${CMAKE_CURRENT_LIST_DIR}/.."
+  ABSOLUTE
+)
+
+function(lynx_resolve_lynxtron_import_library OUT_VAR)
+  if(NOT WIN32)
+    set(${OUT_VAR} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  if(DEFINED LYNXTRON_IMPORT_LIB)
+    file(TO_CMAKE_PATH "${LYNXTRON_IMPORT_LIB}" LYNXTRON_IMPORT_LIB_PATH)
+    if(NOT EXISTS "${LYNXTRON_IMPORT_LIB_PATH}")
+      message(FATAL_ERROR "LYNXTRON_IMPORT_LIB does not exist: ${LYNXTRON_IMPORT_LIB_PATH}")
+    endif()
+
+    set(${OUT_VAR} "${LYNXTRON_IMPORT_LIB_PATH}" PARENT_SCOPE)
+    return()
+  endif()
+
+  if(NOT DEFINED NODE_EXECUTABLE)
+    find_program(NODE_EXECUTABLE NAMES node)
+  endif()
+
+  if(NOT NODE_EXECUTABLE)
+    message(FATAL_ERROR "Unable to find node. Install Node.js before linking Lynxtron native libraries.")
+  endif()
+
+  if(NOT DEFINED LYNX_LIBRARY_PACKAGE_ROOT)
+    set(LYNX_LIBRARY_PACKAGE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
+  endif()
+
+  execute_process(
+    COMMAND
+      "${NODE_EXECUTABLE}"
+      -e
+      "const path=require('node:path');const {createRequire}=require('node:module');try{const r=createRequire(path.join(process.argv[1],'package.json'));const p=r('@lynx-js/lynxtron/native-paths');process.stdout.write(p.importLibraryPath||'')}catch(e){process.exit(1)}"
+      "${LYNX_LIBRARY_HEADERS_PACKAGE_ROOT}"
+    WORKING_DIRECTORY "${LYNX_LIBRARY_PACKAGE_ROOT}"
+    RESULT_VARIABLE LYNXTRON_NATIVE_PATHS_RESULT
+    OUTPUT_VARIABLE LYNXTRON_IMPORT_LIB_FROM_PACKAGE
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(LYNXTRON_NATIVE_PATHS_RESULT EQUAL 0 AND LYNXTRON_IMPORT_LIB_FROM_PACKAGE)
+    file(TO_CMAKE_PATH "${LYNXTRON_IMPORT_LIB_FROM_PACKAGE}" LYNXTRON_IMPORT_LIB_FROM_PACKAGE_PATH)
+    if(EXISTS "${LYNXTRON_IMPORT_LIB_FROM_PACKAGE_PATH}")
+      set(${OUT_VAR} "${LYNXTRON_IMPORT_LIB_FROM_PACKAGE_PATH}" PARENT_SCOPE)
+      return()
+    endif()
+  endif()
+
+  execute_process(
+    COMMAND
+      "${NODE_EXECUTABLE}"
+      -p
+      "const path=require('node:path');const {createRequire}=require('node:module');const r=createRequire(path.join(process.argv[1],'package.json'));let p;try{p=r.resolve('@lynx-js/lynxtron/package.json')}catch(e){p=r.resolve('@lynx-js/lynxtron')}path.dirname(p)"
+      "${LYNX_LIBRARY_HEADERS_PACKAGE_ROOT}"
+    WORKING_DIRECTORY "${LYNX_LIBRARY_PACKAGE_ROOT}"
+    RESULT_VARIABLE LYNXTRON_PACKAGE_ROOT_RESULT
+    OUTPUT_VARIABLE LYNXTRON_PACKAGE_ROOT
+    ERROR_VARIABLE LYNXTRON_PACKAGE_ROOT_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(NOT LYNXTRON_PACKAGE_ROOT_RESULT EQUAL 0 OR NOT LYNXTRON_PACKAGE_ROOT)
+    string(REPLACE "\n" " " LYNXTRON_PACKAGE_ROOT_ERROR "${LYNXTRON_PACKAGE_ROOT_ERROR}")
+    message(FATAL_ERROR "Unable to resolve @lynx-js/lynxtron. Run npm install first. ${LYNXTRON_PACKAGE_ROOT_ERROR}")
+  endif()
+
+  set(LYNXTRON_IMPORT_LIB_CANDIDATES
+    "${LYNXTRON_PACKAGE_ROOT}/dist/lynxtron.dll.lib"
+    "${LYNXTRON_PACKAGE_ROOT}/dist/win32/x64/lynxtron.dll.lib"
+    "${LYNXTRON_PACKAGE_ROOT}/dist/win32/x64/lynxtron/lynxtron.dll.lib"
+  )
+
+  foreach(LYNXTRON_IMPORT_LIB_CANDIDATE IN LISTS LYNXTRON_IMPORT_LIB_CANDIDATES)
+    if(EXISTS "${LYNXTRON_IMPORT_LIB_CANDIDATE}")
+      set(${OUT_VAR} "${LYNXTRON_IMPORT_LIB_CANDIDATE}" PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+
+  message(FATAL_ERROR
+    "Unable to find lynxtron.dll.lib under @lynx-js/lynxtron. "
+    "Run npm install so @lynx-js/lynxtron downloads the Windows runtime, "
+    "or pass -DLYNXTRON_IMPORT_LIB=/absolute/path/to/lynxtron.dll.lib."
+  )
+endfunction()
+
+function(lynx_link_lynxtron_runtime TARGET_NAME)
+  if(NOT WIN32)
+    return()
+  endif()
+
+  lynx_resolve_lynxtron_import_library(LYNXTRON_RESOLVED_IMPORT_LIB)
+  target_link_libraries("${TARGET_NAME}" PRIVATE "${LYNXTRON_RESOLVED_IMPORT_LIB}")
+endfunction()

--- a/src/packages/lynx-library-headers/package.json
+++ b/src/packages/lynx-library-headers/package.json
@@ -17,8 +17,12 @@
   ],
   "files": [
     "include/**/*",
+    "cmake/**/*",
     "README.md"
   ],
+  "dependencies": {
+    "@lynx-js/lynxtron": "workspace:*"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/src/packages/lynxtron-dev-plugins/README.md
+++ b/src/packages/lynxtron-dev-plugins/README.md
@@ -38,8 +38,11 @@ export default defineConfig({
 ## Rspack Usage
 
 Use `pluginLynxtron` in the desktop host Rspack config. It includes Lynxtron
-AutoLink by default, so dependencies with `lynx.lib.json` and a `node-api`
-entry are staged and loaded automatically.
+AutoLink by default, so dependencies with `lynx.lib.json` and a `lynxtron`
+platform record are staged and loaded automatically.
+
+For `lynxtron`, `lynx.lib.json` describes the native asset root, such as
+`dist`, while the package's `./lynxtron` export provides the JS entry.
 
 ```ts
 import { pluginLynxtron } from '@lynx-js/lynxtron-dev-plugins/rspack';

--- a/src/packages/lynxtron-dev-plugins/src/autolink.ts
+++ b/src/packages/lynxtron-dev-plugins/src/autolink.ts
@@ -176,15 +176,24 @@ export function resolveLynxtronAutoLinks(
 
     if (matchedEntry.stageMode === 'package') {
       const requireFromPackage = createRequire(resolvedPackage.packageJsonPath);
+      const lynxtronSpecifier = getNodeApiPackageSpecifier(dependencyName);
 
-      for (const libraryPath of libs) {
-        const specifier = `${dependencyName}/${libraryPath}`;
+      try {
+        requireFromPackage.resolve(lynxtronSpecifier);
+      } catch {
+        libraryWarnings.push(
+          `Lynxtron AutoLink package "${dependencyName}" declares Lynxtron assets, but ${lynxtronSpecifier} cannot be resolved.`
+        );
+      }
 
-        try {
-          requireFromPackage.resolve(specifier);
-        } catch {
+      for (const [index, libPath] of libPaths.entries()) {
+        if (hasGlob(libs[index])) {
+          continue;
+        }
+
+        if (!fs.existsSync(libPath)) {
           libraryWarnings.push(
-            `Lynxtron AutoLink package "${dependencyName}" declares Node-API entry ${specifier}, but it cannot be resolved.`
+            `Lynxtron AutoLink package "${dependencyName}" declares Lynxtron assets ${libs[index]}, but the path does not exist.`
           );
         }
       }
@@ -262,25 +271,19 @@ export function createLynxtronAutoLinkStagedLibraries(
 
   for (const library of resolution.libraries) {
     if (library.stageMode === 'package') {
-      for (const libraryPath of library.libs) {
-        const normalizedLibraryPath = normalizeFilterPath(libraryPath);
-        const stagedPackagePath = path.posix.join(
-          outputRoot,
-          packageNameToNodeModulesPath(library.name)
-        );
+      const stagedPackagePath = path.posix.join(
+        outputRoot,
+        packageNameToNodeModulesPath(library.name)
+      );
 
-        stagedLibraries.push({
-          name: library.name,
-          sourcePath: library.packageRoot,
-          stagedPath: stagedPackagePath,
-          requirePath: path.posix.join(
-            stagedPackagePath,
-            normalizedLibraryPath
-          ),
-          requireSpecifier: `${library.name}/${normalizedLibraryPath}`,
-          copyMode: 'package',
-        });
-      }
+      stagedLibraries.push({
+        name: library.name,
+        sourcePath: library.packageRoot,
+        stagedPath: stagedPackagePath,
+        requirePath: stagedPackagePath,
+        requireSpecifier: getNodeApiPackageSpecifier(library.name),
+        copyMode: 'package',
+      });
       continue;
     }
 
@@ -320,7 +323,13 @@ export function generateLynxtronAutoLinkCode(
     (library) =>
       `  { packageName: ${JSON.stringify(library.name)}, libs: ${JSON.stringify(
         library.libs
-      )}, stageMode: ${JSON.stringify(library.stageMode)} },`
+      )}, stageMode: ${JSON.stringify(
+        library.stageMode
+      )}, specifier: ${JSON.stringify(
+        library.stageMode === 'package'
+          ? getNodeApiPackageSpecifier(library.name)
+          : undefined
+      )} },`
   );
 
   return `import __fs from 'node:fs';
@@ -391,21 +400,22 @@ function __lynxtronAutoLinkLoadNodeApiAddon(libraryPath, isPackageEntry) {
 for (const __lynxtronAutoLinkRecord of __lynxtronAutoLinkLibraries) {
   let __lynxtronAutoLinkPackageRoot;
 
+  if (__lynxtronAutoLinkRecord.stageMode === 'package') {
+    __lynxtronAutoLinkLoadNodeApiAddon(
+      __lynxtronAutoLinkRecord.specifier,
+      true,
+    );
+    continue;
+  }
+
   for (const __lynxtronAutoLinkLib of __lynxtronAutoLinkRecord.libs) {
-    if (__lynxtronAutoLinkRecord.stageMode === 'package') {
-      __lynxtronAutoLinkLoadNodeApiAddon(
-        \`\${__lynxtronAutoLinkRecord.packageName}/\${__lynxtronAutoLinkLib}\`,
-        true,
-      );
-    } else {
-      __lynxtronAutoLinkPackageRoot ??= __lynxtronAutoLinkResolvePackageRoot(
-        __lynxtronAutoLinkRecord.packageName,
-      );
-      __lynxtronAutoLinkLoadNodeApiAddon(
-        __path.join(__lynxtronAutoLinkPackageRoot, __lynxtronAutoLinkLib),
-        false,
-      );
-    }
+    __lynxtronAutoLinkPackageRoot ??= __lynxtronAutoLinkResolvePackageRoot(
+      __lynxtronAutoLinkRecord.packageName,
+    );
+    __lynxtronAutoLinkLoadNodeApiAddon(
+      __path.join(__lynxtronAutoLinkPackageRoot, __lynxtronAutoLinkLib),
+      false,
+    );
   }
 }
 `;
@@ -658,7 +668,7 @@ function getNodeApiManifestEntry(
   const platformRecords = platforms as Record<string, unknown>;
 
   const nodeApiEntry = matchNodeApiManifestEntry(
-    platformRecords['node-api'],
+    platformRecords['lynxtron'],
     platform,
     arch
   );
@@ -697,7 +707,7 @@ function matchNodeApiManifestEntry(
 
   if (paths.length > 0) {
     return {
-      platformKey: 'node-api',
+      platformKey: 'lynxtron',
       archKey: runtimeArch,
       libs: paths,
       stageMode: 'package',
@@ -705,7 +715,7 @@ function matchNodeApiManifestEntry(
   }
 
   return matchBinaryManifestEntry(
-    'node-api',
+    'lynxtron',
     platformEntry,
     runtimePlatform,
     runtimeArch
@@ -811,6 +821,10 @@ function expandManifestVariables(
 
 function packageNameToNodeModulesPath(packageName: string): string {
   return `node_modules/${packageName}`;
+}
+
+function getNodeApiPackageSpecifier(packageName: string): string {
+  return `${packageName}/lynxtron`;
 }
 
 function normalizeRelativePath(value: unknown): string | undefined {

--- a/src/packages/lynxtron/native-paths.cjs
+++ b/src/packages/lynxtron/native-paths.cjs
@@ -1,0 +1,38 @@
+const path = require('node:path');
+
+const packageRoot = __dirname;
+const distRoot = path.join(packageRoot, 'dist');
+
+function platformExecutableName() {
+  if (process.platform === 'win32') {
+    return 'lynxtron.exe';
+  }
+
+  if (process.platform === 'darwin') {
+    return path.join('lynxtron.app', 'Contents', 'MacOS', 'lynxtron');
+  }
+
+  throw new Error(
+    `lynxtron builds are not available on platform: ${process.platform}`
+  );
+}
+
+const executablePath = path.join(distRoot, platformExecutableName());
+
+const dllPath =
+  process.platform === 'win32'
+    ? path.join(distRoot, 'lynxtron.dll')
+    : undefined;
+
+const importLibraryPath =
+  process.platform === 'win32'
+    ? path.join(distRoot, 'lynxtron.dll.lib')
+    : undefined;
+
+module.exports = {
+  packageRoot,
+  distRoot,
+  executablePath,
+  dllPath,
+  importLibraryPath,
+};

--- a/src/packages/lynxtron/package.json
+++ b/src/packages/lynxtron/package.json
@@ -36,6 +36,7 @@
     "fuses.js",
     "fuses-cli.js",
     "install.js",
+    "native-paths.cjs",
     "lynx.js",
     "lynxtron.js",
     "lynxtron_bin.js",
@@ -55,6 +56,8 @@
       "default": "./lynx.js"
     },
     "./fuses": "./fuses.js",
+    "./native-paths": "./native-paths.cjs",
+    "./package.json": "./package.json",
     "./context-bridge": {
       "types": "./apis/api/context-bridge.d.ts",
       "browser": "./web-worker.js",

--- a/src/packages/publish_prepare.py
+++ b/src/packages/publish_prepare.py
@@ -86,6 +86,12 @@ PREPARE_CONFIG = {
     },
     "lynx-library-headers": {
         "package_dir": "./lynx-library-headers",
+        "replaces": {
+            "@lynx-js/lynxtron": {
+                "name": "@lynx-js/lynxtron",
+                "version": "",
+            },
+        },
     },
 }
 

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -1305,6 +1305,8 @@ __metadata:
 "@lynx-js/lynx-library-headers@workspace:packages/lynx-library-headers":
   version: 0.0.0-use.local
   resolution: "@lynx-js/lynx-library-headers@workspace:packages/lynx-library-headers"
+  dependencies:
+    "@lynx-js/lynxtron": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- rename the Lynxtron AutoLink package target from `node-api` to `lynxtron`
- update AutoLink package loading to require `<package>/lynxtron`
- update `@lynx-js/cef-x-webview` manifest, package export, and README usage to the new target name
- expose `@lynx-js/lynxtron/native-paths` so package consumers can resolve installed runtime artifacts
- publish `@lynx-js/lynx-library-headers/cmake/lynx-library-headers.cmake` for Windows Lynx native library builds
- resolve the Windows runtime import library for generated native targets, with `LYNXTRON_IMPORT_LIB` as an override
- update publish preparation so workspace dependency ranges are rewritten to concrete release versions

## Context

PR #28 was already merged, so this follow-up PR carries the target rename on top of the latest `main`. It also carries the package/header side required by the Windows Lynx native library linking fix.

## Related

Companion `create-lynx-library` template changes: https://github.com/lynx-family/lynx-stack/pull/2903.

## Validation

- `yarn install --immutable`
- `yarn workspace @lynx-js/lynxtron-dev-plugins build`
- `git diff --check origin/main..HEAD`
- `python -m py_compile packages/publish_prepare.py`
- verified the headers package root resolves `@lynx-js/lynxtron/native-paths` to the installed `dist/lynxtron.dll.lib`
- locally generated and packed a Lynx native library using the companion stack changes and this headers package
- installed the generated package through the shell demo via `pluginLynxtron`
- smoke checked both `LYNX_NATIVE_ELEMENT_BACKEND=texture` and `LYNX_NATIVE_ELEMENT_BACKEND=native-ui` build paths in Lynxtron shell demo
- smoke checked generated NAPI native module invocation in shell demo