### PR TITLE
[Infra] Add Rslint and automatic style hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+
+python3 "$root/lynxtron_tools/check_push_style.py" --staged --write

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly zero_sha='0000000000000000000000000000000000000000'
+root="$(git rev-parse --show-toplevel)"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "$local_sha" == "$zero_sha" ]]; then
+    continue
+  fi
+
+  base="$remote_sha"
+  if [[ "$remote_sha" == "$zero_sha" ]]; then
+    # Lynxtron PRs contain one commit, so a new remote branch checks that
+    # commit without depending on a possibly stale fork's default branch.
+    base="$(git rev-parse "$local_sha^")"
+  fi
+
+  python3 "$root/lynxtron_tools/check_push_style.py" \
+    --base "$base" \
+    --head "$local_sha"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
           which gn
           gn --version
           python3 src/tools_shared/git_lynx.py check --checkers coding-style
+      - name: Run pre-push style check
+        run: |
+          python3 lynxtron_tools/check_push_style.py \
+            --base HEAD^ \
+            --head HEAD \
+            --github
   macos-lynxtron-build:
     timeout-minutes: 120
     runs-on: lynx-darwin-15.6.1-medium

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@
 /out/
 .venv/
 /src/packages/lynxtron-dev-plugins/dist/
+/lynxtron_tools/style/node_modules/
 # skills
 .trae/
 .claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,12 +143,22 @@ The table below shows the specific tasks performed by `git lynx check`:
 
 These tasks can also be executed individually via commands, for example, the `cpplint` task can be run with `git lynx check --checkers=cpplint`.
 
+Running `yarn install` in `src` or sourcing `lynxtron_tools/envsetup.sh` enables
+the repository's Git hooks. Git does not allow a clone to enable hooks before
+an explicit setup command. Before each commit, staged files are automatically
+formatted with Prettier, clang-format, or GN and staged again, then Rslint checks
+staged JavaScript and TypeScript files. Partially staged files are rejected to
+avoid committing unstaged changes. The pre-push hook and CI run the same checks
+without modifying files. Missing JS tools and pinned native formatters are
+downloaded on demand.
+
 The specific programming languages and tools supported by `coding-style` task:
 
 | Language               | Supported | Formatting Tool |
 | ---------------------- | --------- | --------------- |
 | C,C++,Objective-C,Java | ✅         | clang-format    |
-| TypeScript             | ✅         | prettier        |
+| JavaScript             | ✅         | Prettier, Rslint |
+| TypeScript             | ✅         | Prettier, Rslint |
 | GN                     | ✅         | gn              |
 
 ## Landing Pull Requests

--- a/lynxtron_tools/check_push_style.py
+++ b/lynxtron_tools/check_push_style.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Lynxtron Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+
+
+PRETTIER_EXTENSIONS = {
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".tsx",
+    ".yml",
+    ".yaml",
+}
+RSLINT_EXTENSIONS = {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx"}
+CLANG_FORMAT_EXTENSIONS = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".java",
+    ".m",
+    ".mm",
+}
+GN_EXTENSIONS = {".gn", ".gni"}
+FORMATTED_EXTENSIONS = (
+    PRETTIER_EXTENSIONS | CLANG_FORMAT_EXTENSIONS | GN_EXTENSIONS
+)
+PINNED_FORMAT_TOOLS = {
+    "clang-format": {
+        "release": "clang-format-020d2fb7",
+        "archive": "buildtools-clang-format",
+        "version": "020d2fb",
+        "systems": {"darwin", "linux"},
+    },
+    "gn": {
+        "release": "gn-cc28efe6",
+        "archive": "buildtools-gn",
+        "version": "cc28efe62ef0",
+        "systems": {"darwin", "linux", "windows"},
+    },
+}
+
+
+def run(command: list[str], cwd: Path, *, capture_output: bool = False) -> None:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=capture_output,
+    )
+    if capture_output and result.stdout:
+        print(result.stdout, end="")
+    if capture_output and result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    if result.returncode:
+        raise subprocess.CalledProcessError(result.returncode, command)
+
+
+def changed_files(root: Path, base: str, head: str) -> list[Path]:
+    output = subprocess.check_output(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "-z",
+            base,
+            head,
+        ],
+        cwd=root,
+    )
+    return [
+        root / path.decode()
+        for path in output.split(b"\0")
+        if path and (root / path.decode()).is_file()
+    ]
+
+
+def staged_files(root: Path) -> list[Path]:
+    output = subprocess.check_output(
+        [
+            "git",
+            "diff",
+            "--cached",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "-z",
+        ],
+        cwd=root,
+    )
+    return [
+        root / path.decode()
+        for path in output.split(b"\0")
+        if path and (root / path.decode()).is_file()
+    ]
+
+
+def ensure_pushed_content_is_checked(root: Path, head: str, files: list[Path]) -> None:
+    if not files:
+        return
+    relative_files = [os.fspath(path.relative_to(root)) for path in files]
+    output = subprocess.check_output(
+        ["git", "diff", "--name-only", "-z", head, "--", *relative_files],
+        cwd=root,
+    )
+    modified = [path.decode() for path in output.split(b"\0") if path]
+    if modified:
+        print(
+            "Commit or stash local changes to files included in this push:",
+            file=sys.stderr,
+        )
+        for path in modified:
+            print(f"  {path}", file=sys.stderr)
+        raise RuntimeError("pushed files differ from the working tree")
+
+
+def ensure_staged_content_is_checked(root: Path, files: list[Path]) -> None:
+    if not files:
+        return
+    relative_files = [os.fspath(path.relative_to(root)) for path in files]
+    output = subprocess.check_output(
+        ["git", "diff", "--name-only", "-z", "--", *relative_files],
+        cwd=root,
+    )
+    modified = [path.decode() for path in output.split(b"\0") if path]
+    if modified:
+        print(
+            "The pre-commit formatter cannot safely update partially staged files:",
+            file=sys.stderr,
+        )
+        for path in modified:
+            print(f"  {path}", file=sys.stderr)
+        raise RuntimeError("stage or stash these files before committing")
+
+
+def ensure_js_tools(style_tools: Path) -> tuple[Path, Path]:
+    executable_suffix = ".cmd" if platform.system().lower() == "windows" else ""
+    prettier = (
+        style_tools / "node_modules" / ".bin" / f"prettier{executable_suffix}"
+    )
+    rslint = style_tools / "node_modules" / ".bin" / f"rslint{executable_suffix}"
+    if prettier.is_file() and rslint.is_file():
+        return prettier, rslint
+
+    if not shutil.which("npm"):
+        raise RuntimeError("Node.js with npm is required to install style tools.")
+
+    print("Installing the JavaScript style tools...")
+    run(
+        ["npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"],
+        style_tools,
+    )
+    return prettier, rslint
+
+
+def tool_platform() -> tuple[str, str]:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    machine = {"amd64": "x86_64", "aarch64": "arm64"}.get(machine, machine)
+    return system, machine
+
+
+def tool_has_expected_version(tool: Path, marker: str) -> bool:
+    if not tool.is_file():
+        return False
+    try:
+        version = subprocess.check_output(
+            [tool, "--version"], text=True, stderr=subprocess.STDOUT
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return False
+    return marker in version
+
+
+def extract_tool(archive: Path, destination: Path, binary_name: str) -> Path:
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        extract_root = Path(temporary_directory).resolve()
+        with tarfile.open(archive, "r:gz") as tar:
+            for member in tar.getmembers():
+                member_path = (extract_root / member.name).resolve()
+                if (
+                    not member_path.is_relative_to(extract_root)
+                    or member.issym()
+                    or member.islnk()
+                ):
+                    raise RuntimeError(f"unsafe path in formatter archive: {member.name}")
+            tar.extractall(extract_root)
+
+        matches = list(extract_root.rglob(binary_name))
+        if len(matches) != 1:
+            raise RuntimeError(f"could not find {binary_name} in {archive}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(matches[0], destination)
+        destination.chmod(0o755)
+    return destination
+
+
+def ensure_format_tool(root: Path, name: str) -> Path:
+    metadata = PINNED_FORMAT_TOOLS[name]
+    system, machine = tool_platform()
+    if system not in metadata["systems"]:
+        raise RuntimeError(f"the pinned {name} binary is unavailable on {system}")
+
+    executable_name = f"{name}.exe" if system == "windows" else name
+    repository_candidates = {
+        "clang-format": [
+            root / "src" / "tools_shared" / "buildtools" / "clang-format" / name
+        ],
+        "gn": [
+            root / "buildtools" / "gn" / executable_name,
+            root / "src" / "tools_shared" / "buildtools" / "gn" / executable_name,
+        ],
+    }
+    path_candidate = shutil.which(name)
+    candidates = repository_candidates[name]
+    if path_candidate:
+        candidates.append(Path(path_candidate))
+    for candidate in candidates:
+        if tool_has_expected_version(candidate, metadata["version"]):
+            return candidate
+
+    cache_root = (
+        Path.home()
+        / ".cache"
+        / "lynxtron"
+        / "format-tools"
+        / metadata["release"]
+        / f"{system}-{machine}"
+    )
+    cached_binary = cache_root / executable_name
+    if tool_has_expected_version(cached_binary, metadata["version"]):
+        return cached_binary
+
+    archive_name = f"{metadata['archive']}-{system}-{machine}.tar.gz"
+    url = (
+        "https://github.com/lynx-family/buildtools/releases/download/"
+        f"{metadata['release']}/{archive_name}"
+    )
+    cache_root.mkdir(parents=True, exist_ok=True)
+    archive = cache_root / archive_name
+    print(f"Downloading pinned {name} from {url}...")
+    urllib.request.urlretrieve(url, archive)
+    extract_tool(archive, cached_binary, executable_name)
+    archive.unlink()
+    if not tool_has_expected_version(cached_binary, metadata["version"]):
+        raise RuntimeError(f"downloaded {name} has an unexpected version")
+    return cached_binary
+
+
+def check_newline(files: list[Path]) -> None:
+    missing = [path for path in files if path.read_bytes()[-1:] != b"\n"]
+    if missing:
+        print("The following files must end with a newline:", file=sys.stderr)
+        for path in missing:
+            print(f"  {path}", file=sys.stderr)
+        raise RuntimeError("missing trailing newline")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check or write lint and formatting for changed files."
+    )
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    parser.add_argument("--staged", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--github", action="store_true")
+    args = parser.parse_args()
+
+    if args.staged:
+        if args.base or args.head:
+            parser.error("--staged cannot be combined with --base or --head")
+    elif not args.base or not args.head:
+        parser.error("--base and --head are required unless --staged is used")
+    if args.write and not args.staged:
+        parser.error("--write requires --staged")
+
+    root = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], text=True
+        ).strip()
+    )
+    src = root / "src"
+    style_tools = root / "lynxtron_tools" / "style"
+    if args.staged:
+        files = staged_files(root)
+        ensure_staged_content_is_checked(root, files)
+    else:
+        files = changed_files(root, args.base, args.head)
+        ensure_pushed_content_is_checked(root, args.head, files)
+    formatted_files = [path for path in files if path.suffix in FORMATTED_EXTENSIONS]
+
+    if formatted_files and not args.write:
+        check_newline(formatted_files)
+
+    prettier_files = [path for path in files if path.suffix in PRETTIER_EXTENSIONS]
+    rslint_files = [
+        path
+        for path in files
+        if path.suffix in RSLINT_EXTENSIONS and path.is_relative_to(src)
+    ]
+    if prettier_files or rslint_files:
+        prettier, rslint = ensure_js_tools(style_tools)
+
+    if prettier_files:
+        run(
+            [
+                prettier,
+                "--write" if args.write else "--check",
+                *[os.fspath(path) for path in prettier_files],
+            ],
+            src,
+        )
+
+    clang_files = [path for path in files if path.suffix in CLANG_FORMAT_EXTENSIONS]
+    if clang_files:
+        clang_format = ensure_format_tool(root, "clang-format")
+        for path in clang_files:
+            if args.write:
+                run([clang_format, "-i", path], root)
+            else:
+                formatted = subprocess.check_output(
+                    [clang_format, os.fspath(path)], cwd=root
+                )
+                if formatted != path.read_bytes():
+                    raise RuntimeError(f"clang-format check failed for {path}")
+
+    gn_files = [path for path in files if path.suffix in GN_EXTENSIONS]
+    if gn_files:
+        gn = ensure_format_tool(root, "gn")
+        for path in gn_files:
+            command = [gn, "format"]
+            if not args.write:
+                command.append("--dry-run")
+            command.append(os.fspath(path))
+            result = subprocess.run(
+                command,
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout:
+                print(result.stdout, end="")
+            if result.stderr:
+                print(result.stderr, end="", file=sys.stderr)
+            if result.returncode or (
+                not args.write and (result.stdout or result.stderr)
+            ):
+                raise RuntimeError(f"GN formatting failed for {path}")
+
+    if args.write and formatted_files:
+        check_newline(formatted_files)
+        run(
+            [
+                "git",
+                "add",
+                "--",
+                *[os.fspath(path.relative_to(root)) for path in formatted_files],
+            ],
+            root,
+        )
+        print(f"Formatted and staged {len(formatted_files)} file(s).")
+
+    if rslint_files:
+        command = [rslint, "--config", style_tools / "rslint.config.mjs"]
+        if args.github:
+            command.extend(["--format", "github"])
+        command.extend(os.fspath(path.relative_to(src)) for path in rslint_files)
+        run(command, src)
+
+    print(f"Rslint and formatting checks passed for {len(files)} changed file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"style check failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/lynxtron_tools/envsetup.ps1
+++ b/lynxtron_tools/envsetup.ps1
@@ -13,6 +13,7 @@ function Lynxtron-Env-Setup {
     $env:PATH += ';'
     $env:PATH += Join-Path $buildtoolsDir 'gn;'
     $env:PATH += Join-Path $buildtoolsDir 'ninja;'
+    git -C $lynxtron_dir_path config core.hooksPath .githooks
 }
 
 function Python-Env-Setup {

--- a/lynxtron_tools/envsetup.sh
+++ b/lynxtron_tools/envsetup.sh
@@ -20,19 +20,8 @@ lynxtron_envsetup() {
   export PATH=${CLANGFORMAT_DIR}:${TOOLSSHARED_DIR}:${BUILDTOOLS_DIR}/sccache:${BUILDTOOLS_DIR}/llvm/bin:${BUILDTOOLS_DIR}/gn:${BUILDTOOLS_DIR}/ninja:${BUILDTOOLS_DIR}/node/bin:$PATH
   echo "BUILDTOOLS_DIR: $BUILDTOOLS_DIR"
 
-  # install git hooks
-  local GIT_HOOKS_DIR=$(git rev-parse --git-path hooks)
-  local HOOKS_DIR=$LYNXTRON_ROOT_DIR/tools/hooks
-  local REAL_GIT_HOOKS_DIR=$(posix_realpath $GIT_HOOKS_DIR)
-  if [ x$REAL_GIT_HOOKS_DIR != x$HOOKS_DIR ]; then
-    if [ -L $GIT_HOOKS_DIR ]; then
-      rm -f $GIT_HOOKS_DIR
-    elif [ -d $GIT_HOOKS_DIR ]; then
-      rm -rf "${GIT_HOOKS_DIR}.bak"
-      mv $GIT_HOOKS_DIR "${GIT_HOOKS_DIR}.bak"
-    fi
-    ln -sf $HOOKS_DIR $GIT_HOOKS_DIR
-  fi
+  # Install repository-managed Git hooks.
+  git -C "$LYNXTRON_ROOT_DIR" config core.hooksPath .githooks
 }
 
 function python_env_setup() {

--- a/lynxtron_tools/style/package-lock.json
+++ b/lynxtron_tools/style/package-lock.json
@@ -1,0 +1,188 @@
+{
+  "name": "lynxtron-style-tools",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lynxtron-style-tools",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@rslint/core": "0.6.5",
+        "prettier": "3.9.5"
+      }
+    },
+    "node_modules/@rslint/core": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/core/-/core-0.6.5.tgz",
+      "integrity": "sha512-BAy65hSKOhHrma20Rxqf1DTyGNYBSQGBeo21JKc0bgHzbkTbUcyPSz6EpdI3woDe0HqwGmOsl/tPTGqKvgsz3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "4.0.4"
+      },
+      "bin": {
+        "rslint": "bin/rslint.js"
+      },
+      "optionalDependencies": {
+        "@rslint/native-darwin-arm64": "0.6.5",
+        "@rslint/native-darwin-x64": "0.6.5",
+        "@rslint/native-linux-arm64-gnu": "0.6.5",
+        "@rslint/native-linux-arm64-musl": "0.6.5",
+        "@rslint/native-linux-x64-gnu": "0.6.5",
+        "@rslint/native-linux-x64-musl": "0.6.5",
+        "@rslint/native-win32-arm64-msvc": "0.6.5",
+        "@rslint/native-win32-x64-msvc": "0.6.5"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rslint/native-darwin-arm64": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/native-darwin-arm64/-/native-darwin-arm64-0.6.5.tgz",
+      "integrity": "sha512-5HDBqR1XgZ29pNEjSnm/YccWpwEWEl9d8rUQZkbDUz3x2VWylfok8Ty1qjDHVAas1k01euMS1YJA4/nku9N0Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rslint/native-darwin-x64": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/native-darwin-x64/-/native-darwin-x64-0.6.5.tgz",
+      "integrity": "sha512-YU8w9N7NbBBDZ/B8nsmZmVLL5A40AnUxsywsCvDT6nPUhEqHJvCbwze5LHQFT4RvhJEfC/ye/7pqL59SnKN5tA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rslint/native-linux-arm64-gnu": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/native-linux-arm64-gnu/-/native-linux-arm64-gnu-0.6.5.tgz",
+      "integrity": "sha512-IGt5Op5dKO9ZbI9vOjZrgBnAM3QfT/X7PNjUVmYYso8OvseapzQv0E6D8qgTJVrN5874VWBwXgc7a/cylYR6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rslint/native-linux-arm64-musl": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/native-linux-arm64-musl/-/native-linux-arm64-musl-0.6.5.tgz",
+      "integrity": "sha512-cywsTmLudo4a6Rlp4bsriS9QF4n0aMZc25ArgxB/j3sIzHSREIoNdUYx1VHz7pOUJy2W5wmNfHIVWb+uz6R6eA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rslint/native-linux-x64-gnu": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/native-linux-x64-gnu/-/native-linux-x64-gnu-0.6.5.tgz",
+      "integrity": "sha512-4/d3jkZQ0lnf1GtiB0WCLoXfMCPxD04mihVNWmC2qNj5JF8OKTg9tKbfpwZNjJDDVK0noj9JiynQGhVUZCMNDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rslint/native-linux-x64-musl": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/native-linux-x64-musl/-/native-linux-x64-musl-0.6.5.tgz",
+      "integrity": "sha512-uz0q2MBm+iAbe+ecFA3JKsmlN12DWxNQYF0wHn81kpF5QPMlM62xsYFLHIs4ER7FtC2oR3SOtCcWsyIGRCiBxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rslint/native-win32-arm64-msvc": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/native-win32-arm64-msvc/-/native-win32-arm64-msvc-0.6.5.tgz",
+      "integrity": "sha512-bud+61vGaVBO1ykKvaM1vtPILQi0cl5nad0DboBmo4EtEykbZyapZ3aM/g8NV/ldJmkNaFQdwuXcrdfA9+d7Vg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rslint/native-win32-x64-msvc": {
+      "version": "0.6.5",
+      "resolved": "https://bnpm.byted.org/@rslint/native-win32-x64-msvc/-/native-win32-x64-msvc-0.6.5.tgz",
+      "integrity": "sha512-7iQozrpTvh/Vj7x5jTYaG+9zKWJkiXz0PgemFNUMIXLCZHWsJffPy7D1ls5q2Rfe6hshFJ9d6UxGk1KmLpZQiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://bnpm.byted.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://bnpm.byted.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/lynxtron_tools/style/package.json
+++ b/lynxtron_tools/style/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lynxtron-style-tools",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@rslint/core": "0.6.5",
+    "prettier": "3.9.5"
+  }
+}

--- a/lynxtron_tools/style/rslint.config.mjs
+++ b/lynxtron_tools/style/rslint.config.mjs
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynxtron Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig, js, ts } from '@rslint/core';
+
+export default defineConfig([
+  js.configs.recommended,
+  ts.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': 'warn',
+      'no-empty': 'warn',
+      'no-undef': 'off',
+    },
+  },
+]);

--- a/src/package.json
+++ b/src/package.json
@@ -23,6 +23,7 @@
     "wrapper-webpack-plugin": "^2.2.0"
   },
   "scripts": {
+    "postinstall": "node -e \"require(require('path').join(require('path').dirname(process.env.npm_package_json), 'script/install-git-hooks.js'))\"",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish",

--- a/src/prettier.config.js
+++ b/src/prettier.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   singleQuote: true,
+  trailingComma: 'es5',
 };

--- a/src/script/install-git-hooks.js
+++ b/src/script/install-git-hooks.js
@@ -1,0 +1,15 @@
+// Copyright 2026 The Lynxtron Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const packageJson = process.env.npm_package_json;
+if (!packageJson) {
+  throw new Error('npm_package_json is required to install Git hooks');
+}
+const root = path.resolve(path.dirname(packageJson), '..');
+execFileSync('git', ['-C', root, 'config', 'core.hooksPath', '.githooks'], {
+  stdio: 'inherit',
+});


### PR DESCRIPTION
## Summary

- add Rstack's `@rslint/core` with the recommended JavaScript and TypeScript rules
- upgrade the repository-managed formatter to Prettier 3.9.5 while preserving the existing trailing-comma style
- add a pre-commit hook that formats staged files and stages the formatted output
- add a pre-push hook and CI job that verify the committed files without modifying them
- bootstrap a minimal, isolated set of style tools on demand

## Motivation

The existing coding-style checker downloads Prettier 2.2.1 on demand. That old parser rejects newer TypeScript syntax, and style failures are often discovered only after a branch is pushed. This change makes the JavaScript tooling explicit, formats supported files before Git creates a commit, and keeps pre-push and CI as read-only safeguards.

The pre-commit hook runs Prettier for JavaScript, TypeScript, and YAML; clang-format for C, C++, Objective-C, and Java; and `gn format` for GN files. It stages the formatted files before allowing the commit to continue, then runs Rslint for staged JavaScript and TypeScript. It rejects partially staged checked files instead of risking the inclusion of unstaged changes. Rslint fixes are not applied automatically.

Git intentionally does not enable hooks merely by cloning a repository. A normal dependency install in `src`, or `source lynxtron_tools/envsetup.sh`, enables the tracked hooks. Once enabled, no envsetup or `src` dependency install is required: the hooks install only the isolated npm style packages when needed and lazily download the repository-pinned clang-format or GN binary when the changed files require it.

## Verification

- committed deliberately unformatted JavaScript, C++, and GN files from a fresh clone with an empty HOME and no project dependencies; all three were formatted and staged automatically
- verified `git commit --amend --no-edit` includes the automatically formatted output
- verified partially staged checked files are rejected without changing the index
- exercised `.githooks/pre-push` with a new-branch push payload
- tested pinned clang-format and GN downloads with an empty tool cache
- ran the complete PR style check with Prettier 3 and Rslint
