### PR TITLE
[Infra][Test] Decouple NODE_OPTIONS error from product name

### DIFF
--- a/src/spec/node-spec.ts
+++ b/src/spec/node-spec.ts
@@ -208,7 +208,6 @@ describe('node feature', () => {
     let child: childProcess.ChildProcessWithoutNullStreams;
     let exitPromise: Promise<any[]>;
 
-    // FIXME(Guo Xi): Fix it
     ifit(process.platform !== 'win32')(
       'Fails for options disallowed by Node.js itself',
       (done) => {
@@ -239,7 +238,7 @@ describe('node feature', () => {
         const listener = (data: Buffer) => {
           output += data;
           if (
-            /electron: --v8-options is not allowed in NODE_OPTIONS/m.test(
+            /--v8-options is not allowed in NODE_OPTIONS/m.test(
               output
             )
           ) {


### PR DESCRIPTION
## Summary

- Match the Node.js `NODE_OPTIONS` rejection message independently of the executable-name prefix.
- Remove the resolved `FIXME` marker from the test.

## Why

Node formats this startup error using `argv[0]`. Lynxtron therefore reports `lynxtron: --v8-options is not allowed in NODE_OPTIONS`, while the migrated test still required the Electron-specific `electron:` prefix. The option was rejected correctly with exit code 9, but the stale branding assertion caused a false failure.

## Impact

The test continues to verify the exact rejection reason and CLI parsing exit code without coupling the behavior to a product name.

## Validation

- `npm run test --prefix src -- --files spec/node-spec.ts` — 18 passed, 0 failed.
- Repeated on the final `main` baseline with `IGNORE_YARN_INSTALL_ERROR=1`; 18 passed, 0 failed. The bypass was only for an unrelated local immutable-install hash mismatch caused by untracked `dialog-helper` build artifacts.
