### PR TITLE
[BugFix][Lynx] Load file URLs through local file path

### DIFF
--- a/src/shell/api/api_lynx_window.cc
+++ b/src/shell/api/api_lynx_window.cc
@@ -30,6 +30,7 @@
 #include "shell/app/window_list.h"
 #include "shell/common/asar/archive.h"
 #include "shell/common/asar/asar_util.h"
+#include "shell/common/file_url_util.h"
 #include "shell/common/gin_helper/constructor.h"
 #include "shell/common/gin_helper/dictionary.h"
 #include "shell/common/gin_helper/object_template_builder.h"
@@ -626,6 +627,16 @@ bool LynxWindow::LoadFile(const std::string& path, gin::Arguments* args) {
 }
 
 bool LynxWindow::LoadUrl(const std::string& url, gin::Arguments* args) {
+  GURL parsed_url(url);
+  if (parsed_url.SchemeIsFile()) {
+    base::FilePath local_path;
+    if (!FileURLToFilePath(parsed_url, &local_path)) {
+      LOG(ERROR) << "Invalid file URL: " << url;
+      return false;
+    }
+    return LoadFile(local_path.AsUTF8Unsafe(), args);
+  }
+
   gin_helper::Dictionary data;
   gin_helper::Dictionary global_props;
   if (!ExtractLoadDataOptions(args, &data, &global_props)) {

--- a/src/spec/api-lynx-window-template-api-spec.ts
+++ b/src/spec/api-lynx-window-template-api-spec.ts
@@ -10,7 +10,6 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { ifit } from './lib/spec-helpers';
 import { closeAllWindows } from './lib/window-helpers';
 
 const { LynxTemplateBundle } = require('lynxtron') as {
@@ -107,55 +106,45 @@ describe('LynxWindow template APIs', () => {
     expect(w.isDestroyed()).to.equal(false);
   });
 
-  // FIXME(Guo Xi): Fix it
-  ifit(process.platform !== 'win32')(
-    'loadURL(url, { data, globalProps }) accepts a file URL source',
-    async function () {
-      if (!fs.existsSync(bundlePath)) {
-        this.skip();
-      }
+  it('loadURL(url, { data, globalProps }) accepts a file URL source', async function () {
+    if (!fs.existsSync(bundlePath)) {
+      this.skip();
+    }
 
-      const w = createWindow('LynxWindow loadURL(file URL)');
+    const w = createWindow('LynxWindow loadURL(file URL)');
 
+    await loadAndWait(w, () =>
+      (w as any).loadURL(pathToFileURL(bundlePath).href, {
+        data: { foo: 'bar' },
+        globalProps: { ver: 1 },
+      })
+    );
+    expect(w.isDestroyed()).to.equal(false);
+  });
+
+  it('loadURL(url) decodes percent-escaped file URLs', async function () {
+    if (!fs.existsSync(bundlePath)) {
+      this.skip();
+    }
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lynxtron-bundle-'));
+    const copiedBundlePath = path.join(
+      tempDir,
+      'bundle with space.lynx.bundle'
+    );
+    fs.copyFileSync(bundlePath, copiedBundlePath);
+
+    const w = createWindow('LynxWindow loadURL(percent-escaped file URL)');
+
+    try {
       await loadAndWait(w, () =>
-        (w as any).loadURL(pathToFileURL(bundlePath).href, {
-          data: { foo: 'bar' },
-          globalProps: { ver: 1 },
-        })
+        (w as any).loadURL(pathToFileURL(copiedBundlePath).href)
       );
       expect(w.isDestroyed()).to.equal(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
     }
-  );
-
-  // FIXME(Guo Xi): Fix it
-  ifit(process.platform !== 'win32')(
-    'loadURL(url) decodes percent-escaped file URLs',
-    async function () {
-      if (!fs.existsSync(bundlePath)) {
-        this.skip();
-      }
-
-      const tempDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), 'lynxtron-bundle-')
-      );
-      const copiedBundlePath = path.join(
-        tempDir,
-        'bundle with space.lynx.bundle'
-      );
-      fs.copyFileSync(bundlePath, copiedBundlePath);
-
-      const w = createWindow('LynxWindow loadURL(percent-escaped file URL)');
-
-      try {
-        await loadAndWait(w, () =>
-          (w as any).loadURL(pathToFileURL(copiedBundlePath).href)
-        );
-        expect(w.isDestroyed()).to.equal(false);
-      } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
-    }
-  );
+  });
 
   it('loadBundle(templateBundle, { data, globalProps }) accepts a pre-decoded bundle', async function () {
     if (typeof LynxTemplateBundle !== 'function') {


### PR DESCRIPTION
Route file: URLs through the existing local bundle loader so percent-escaped paths are decoded and local file, ASAR, data, and globalProps behavior stays consistent with loadFile(). Re-enable the file URL specs on every platform now that the shared conversion handles platform-specific paths.

Verified with: ninja -C out/Debug lynxtron_app

Verified with: npm run test --prefix src -- --files spec/api-lynx-window-template-api-spec.ts