### PR TITLE
[Infra][Test] Decouple NODE_OPTIONS error from product name

### DIFF
--- a/src/spec/node-spec.ts
+++ b/src/spec/node-spec.ts
@@ -208,7 +208,6 @@ describe('node feature', () => {
     let child: childProcess.ChildProcessWithoutNullStreams;
     let exitPromise: Promise<any[]>;
 
-    // FIXME(Guo Xi): Fix it
     ifit(process.platform !== 'win32')(
       'Fails for options disallowed by Node.js itself',
       (done) => {
@@ -238,11 +237,7 @@ describe('node feature', () => {
 
         const listener = (data: Buffer) => {
           output += data;
-          if (
-            /electron: --v8-options is not allowed in NODE_OPTIONS/m.test(
-              output
-            )
-          ) {
+          if (/--v8-options is not allowed in NODE_OPTIONS/m.test(output)) {
             success = true;
             cleanup();
             done();


### PR DESCRIPTION
Summary: Match the Node.js rejection message independently of the executable prefix so Lynxtron branding does not cause a false test failure.

Verified with: npm run test --prefix src -- --files spec/node-spec.ts