### PR TITLE
[BugFix][Lynx] Prevent GC crash from missing V8 HandleScope

### DIFF
--- a/src/shell/api/lynx_view/module/lynx_emit_event.cc
+++ b/src/shell/api/lynx_view/module/lynx_emit_event.cc
@@ -22,13 +22,12 @@ LynxEmitEvent::LynxEmitEvent(InvokeCallback callback)
 LynxEmitEvent::~LynxEmitEvent() {
   if (callback_) {
     v8::Isolate* isolate = JavascriptEnvironment::GetIsolate();
+    v8::HandleScope scope(isolate);
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
     // If there's no current context, it means we're shutting down, so we don't
     // need to send an event.
-    if (!isolate->GetCurrentContext().IsEmpty()) {
-      v8::HandleScope scope(isolate);
-
+    if (!context.IsEmpty()) {
       v8::Local<v8::Object> data = v8::Object::New(isolate);
-      v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
       if (data->Set(context, v8::String::NewFromUtf8Literal(isolate, "error"),
                     v8::String::NewFromUtf8Literal(isolate,

--- a/src/spec/api-lynx-window-template-api-spec.ts
+++ b/src/spec/api-lynx-window-template-api-spec.ts
@@ -8,6 +8,7 @@ import * as fs from 'node:fs';
 import { once } from 'node:events';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 
 import { ifit } from './lib/spec-helpers';
@@ -90,6 +91,54 @@ describe('LynxWindow template APIs', () => {
       })
     );
     expect(w.isDestroyed()).to.equal(false);
+  });
+
+  it('does not crash when collecting an unanswered Lynx bridge event', async function () {
+    if (!fs.existsSync(bundlePath)) {
+      this.skip();
+    }
+
+    await (async () => {
+      const w = createWindow('LynxWindow unanswered bridge event');
+      const invokePromise = new Promise<{
+        methodName: string;
+        params: any;
+        hasSendReply: boolean;
+      }>((resolve) => {
+        (w as any).once(
+          '-lynx-invoke',
+          (callback: any, methodName: string, params: any) => {
+            resolve({
+              methodName,
+              params,
+              hasSendReply: typeof callback.sendReply === 'function',
+            });
+          }
+        );
+      });
+
+      await loadAndWait(w, () =>
+        (w as any).loadFile(bundlePath, {
+          data: { foo: 'bar' },
+          globalProps: { ver: 1 },
+        })
+      );
+
+      const { methodName, params, hasSendReply } = await invokePromise;
+      expect(methodName).to.equal('onRender-test-event');
+      expect(params.msg).to.equal('test-test');
+      expect(hasSendReply).to.equal(true);
+
+      // Intentionally leave the bridge event unanswered. Releasing the window
+      // and the local callback reference makes its wrapper eligible for GC.
+      await closeAllWindows();
+    })();
+    await setTimeout();
+
+    const v8Util = process._linkedBinding('lynxtron_binding_v8_util');
+    v8Util.requestGarbageCollectionForTesting();
+
+    await setTimeout();
   });
 
   it('emits ready-to-show when template loading completes', async function () {


### PR DESCRIPTION
Create a V8 HandleScope before retrieving the current context when an unanswered LynxEmitEvent is finalized by a second-pass weak callback. Add a regression test that loads a Lynx bundle, releases the window, and forces garbage collection.

Verified with: ninja -C out/Debug lynxtron_app

Verified with: npm run test --prefix src -- --grep "does not crash when collecting an unanswered resource event"