### PR TITLE
[BugFix] Fix windows rebuild problem.

### DIFF
--- a/src/packages/lynxtron-rebuild/lib/index.js
+++ b/src/packages/lynxtron-rebuild/lib/index.js
@@ -2,26 +2,28 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import fs from 'node:fs';
 import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { zip } from 'compressing';
 import fetch from 'node-fetch';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
 
 const BASE_URL = '';
 
 function getLynxtronVersion() {
   let pkgPath;
-  
+
   try {
     pkgPath = path.join(process.cwd(), 'node_modules', '@lynx-js', 'lynxtron', 'package.json');
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-    return pkg.version;
+    return { version: pkg.version, lynxtronPkgPath: pkgPath };
   } catch (e) {
     try {
       pkgPath = path.join(__dirname, '..', '..', '..', 'node_modules', '@lynx-js', 'lynxtron', 'package.json');
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-      return pkg.version;
+      return { version: pkg.version, lynxtronPkgPath: pkgPath };
     } catch (e2) {
       throw new Error('Could not find @lynx-js/lynxtron package');
     }
@@ -45,42 +47,67 @@ async function downloadHeaders(version, distDir) {
   const url = `${BASE_URL}v${version}/lynxtron-v${version}-node-headers.zip`;
   const zipPath = path.join(distDir, `lynxtron-v${version}-node-headers.zip`);
   const headersPath = path.join(distDir, `v${version}`);
-  
+
   if (fs.existsSync(headersPath)) {
     console.log(`Headers already exist at ${headersPath}, skipping download`);
     return headersPath;
   }
-  
+
   if (!fs.existsSync(distDir)) {
     fs.mkdirSync(distDir, { recursive: true });
   }
-  
+
   console.log(`Downloading headers from ${url}`);
   await downloadFile(url, zipPath);
-  
+
   console.log(`Extracting headers to ${distDir}`);
   await extractZip(zipPath, distDir);
-  
+
   const extractedDir = path.join(distDir, 'node_headers');
   if (fs.existsSync(extractedDir)) {
     fs.renameSync(extractedDir, headersPath);
   }
-  
+
   fs.unlinkSync(zipPath);
-  
+
   return headersPath;
+}
+
+// The lynxtron node-headers tarball does not ship a Windows `node.lib` import
+// library. node-gyp's msvs template links native addons against
+// `<nodedir>/<Configuration>/node.lib`, so on Windows we seed each expected
+// configuration directory with a copy of `lynxtron.dll.lib` from
+// `@lynx-js/lynxtron`, renamed to `node.lib`.
+function ensureWindowsNodeLib(headersDir, lynxtronPkgPath) {
+  if (process.platform !== 'win32') return;
+
+  const lynxtronDist = path.join(path.dirname(lynxtronPkgPath), 'dist');
+  const src = path.join(lynxtronDist, 'lynxtron.dll.lib');
+  if (!fs.existsSync(src)) {
+    console.warn(`[lynxtron-rebuild] lynxtron.dll.lib not found at ${src}; skipping node.lib seeding`);
+    return;
+  }
+
+  for (const config of ['Release', 'Debug']) {
+    const targetDir = path.join(headersDir, config);
+    const targetLib = path.join(targetDir, 'node.lib');
+    if (fs.existsSync(targetLib)) continue;
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.copyFileSync(src, targetLib);
+    console.log(`[lynxtron-rebuild] Seeded ${targetLib} from lynxtron.dll.lib`);
+  }
 }
 
 function findModulesWithNativeCode(buildPath) {
   const modules = [];
   const nodeModulesPath = path.join(buildPath, 'node_modules');
-  
+
   if (!fs.existsSync(nodeModulesPath)) {
     return modules;
   }
-  
+
   const packages = fs.readdirSync(nodeModulesPath, { withFileTypes: true });
-  
+
   for (const pkg of packages) {
     if (pkg.name.startsWith('.')) continue;
 
@@ -104,8 +131,22 @@ function findModulesWithNativeCode(buildPath) {
       modules.push(pkgPath);
     }
   }
-  
+
   return modules;
+}
+
+function resolveNodeGypScript(modulePath) {
+  const candidates = [
+    path.join(modulePath, 'node_modules', 'node-gyp', 'bin', 'node-gyp.js'),
+    path.join(process.cwd(), 'node_modules', 'node-gyp', 'bin', 'node-gyp.js'),
+  ];
+  try {
+    candidates.push(require.resolve('node-gyp/bin/node-gyp.js'));
+  } catch {}
+  for (const c of candidates) {
+    if (c && fs.existsSync(c)) return c;
+  }
+  return null;
 }
 
 async function rebuildModule(modulePath, headersDir, electronVersion, arch) {
@@ -118,18 +159,39 @@ async function rebuildModule(modulePath, headersDir, electronVersion, arch) {
       '--build-from-source',
       '--nodedir', headersDir
     ];
-    
+
     console.log(`Rebuilding ${path.basename(modulePath)}...`);
-    
-    const nodeGyp = spawn('npx', ['node-gyp', ...args], {
-      cwd: modulePath,
-      stdio: 'inherit'
+
+    // Prefer invoking node-gyp directly. Falling back to `npx` fails on
+    // Windows because Node's `spawn` won't resolve `.cmd`/`.ps1` shims
+    // without `shell: true`, and npx will also try to auto-install a fresh
+    // copy of node-gyp into an unexpected path.
+    const nodeGypJs = resolveNodeGypScript(modulePath);
+    const command = nodeGypJs ? process.execPath : 'npx';
+    const commandArgs = nodeGypJs ? [nodeGypJs, ...args] : ['node-gyp', ...args];
+
+    // pnpm installs each package as a junction/symlink into the .pnpm store.
+    // node-gyp shells out to `node -p "require('node-addon-api').gyp"` with
+    // cwd at the module directory. If we pass the symlink path, Node's
+    // require resolver walks up the *symlink* path and does not see the
+    // package's real siblings inside the store, so `require('node-addon-api')`
+    // fails. Resolve the real path so gyp runs inside the store where the
+    // package's dependency junctions are visible.
+    let realCwd = modulePath;
+    try {
+      realCwd = fs.realpathSync(modulePath);
+    } catch {}
+
+    const nodeGyp = spawn(command, commandArgs, {
+      cwd: realCwd,
+      stdio: 'inherit',
+      shell: !nodeGypJs && process.platform === 'win32'
     });
-    
+
     nodeGyp.on('error', (err) => {
       reject(err);
     });
-    
+
     nodeGyp.on('close', (code) => {
       if (code === 0) {
         console.log(`Successfully rebuilt ${path.basename(modulePath)}`);
@@ -142,28 +204,30 @@ async function rebuildModule(modulePath, headersDir, electronVersion, arch) {
 }
 
 export async function lynxtronRebuild(options = {}) {
-  const version = getLynxtronVersion();
+  const { version, lynxtronPkgPath } = getLynxtronVersion();
   console.log(`Detected Lynxtron version: ${version}`);
-  
+
   const arch = options.arch || process.arch;
   console.log(`Using architecture: ${arch}`);
-  
+
   const distDir = path.join(__dirname, '..', 'dist');
   const headersDir = await downloadHeaders(version, distDir);
-  
+
   console.log(`Headers downloaded to: ${headersDir}`);
-  
+
+  ensureWindowsNodeLib(headersDir, lynxtronPkgPath);
+
   const buildPath = options.buildPath || process.cwd();
   const modules = findModulesWithNativeCode(buildPath);
-  
+
   if (modules.length === 0) {
     console.log('No native modules found to rebuild');
     return;
   }
-  
+
   console.log(`Found ${modules.length} native module(s) to rebuild:`);
   modules.forEach(m => console.log(`  - ${path.basename(m)}`));
-  
+
   for (const modulePath of modules) {
     try {
       await rebuildModule(modulePath, headersDir, version, arch);
@@ -172,6 +236,6 @@ export async function lynxtronRebuild(options = {}) {
       throw err;
     }
   }
-  
+
   console.log('Rebuild completed successfully!');
 }


### PR DESCRIPTION
1. Seed ode.lib for Windows builds.
2. Invoke node-gyp directly instead of via npx