### PR TITLE
[Infra][Test] Avoid incompatible hoisted Rspeedy in Lynx card builds

### DIFF
--- a/src/spec/case/lynx-card/build-all.js
+++ b/src/spec/case/lynx-card/build-all.js
@@ -6,6 +6,11 @@ const path = require('node:path');
 
 const projectRoot = __dirname;
 const distDir = path.resolve(projectRoot, 'dist');
+const rspeedyPackagePath = require.resolve('@lynx-js/rspeedy/package.json');
+const rspeedyBin = path.resolve(
+  path.dirname(rspeedyPackagePath),
+  require(rspeedyPackagePath).bin.rspeedy
+);
 
 const { entries } = require('./cards.config');
 const allProjects = Object.keys(entries);


### PR DESCRIPTION
Resolve and execute the Rspeedy binary declared by the Lynx card fixture instead of relying on the parent process PATH, which may select an incompatible hoisted workspace version.