### PR TITLE
[BugFix][Lynx] Enable inline CSS variables in generated apps

### DIFF
--- a/src/.changeset/bright-pandas-style.md
+++ b/src/.changeset/bright-pandas-style.md
@@ -1,0 +1,5 @@
+---
+'create-lynxtron': patch
+---
+
+Enable inline CSS variables in the default Lynxtron page configuration.

--- a/src/packages/lynxtron-shell-demo/lynx.config.ts
+++ b/src/packages/lynxtron-shell-demo/lynx.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
       {
         alignMouseEventWithW3C: true,
         enableCSSInheritance: true,
+        enableCSSInlineVariables: true,
       },
       {
         configKeys: [...configKeys, 'alignMouseEventWithW3C'],


### PR DESCRIPTION
## Summary

- enable `enableCSSInlineVariables` in the default Lynxtron PageConfig
- include the setting in projects generated by `create-lynxtron`
- add a patch changeset for `create-lynxtron`

## Motivation

Lynx runtime support for inline CSS variables is guarded by PageConfig and defaults to disabled when the option is omitted. As a result, custom properties passed through ReactLynx runtime styles cannot be resolved by `var()`, including from pseudo-class rules such as `:hover`, in newly generated Lynxtron projects.

Related: lynx-family/lynx#8325

## Validation

- built `create-lynxtron` and verified a generated project's `lynx.config.ts` contains `enableCSSInlineVariables: true`
- built `@lynx-js/lynxtron-dev-plugins`
- built `lynxtron-shell-demo`
- verified the generated Lynx bundle PageConfig contains `"enableCSSInlineVariables": true`
- validated the `create-lynxtron` patch changeset
