### PR TITLE
[Feature][CI] Support macOS x64 build and rename x-webview to webview

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: lynx-darwin-15.6.1-medium
     strategy:
       matrix:
-        arch: [arm64]
+        arch: [arm64, x64]
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -310,7 +310,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [arm64]
+        arch: [arm64, x64]
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -535,7 +535,7 @@ jobs:
     runs-on: lynx-darwin-15.6.1-medium
     strategy:
       matrix:
-        arch: [arm64]
+        arch: [arm64, x64]
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2

--- a/src/patches/lynx/.patches
+++ b/src/patches/lynx/.patches
@@ -5,3 +5,4 @@
 0005-Change-COREPACK_ENABLE_NETWORK-to-1-form-0.patch
 0006-BugFix-macOS-Align-TestBench-bridge-replay-with-Lynx.patch
 0008-BugFix-Copy-fetch-response-body-into-V8-sandbox.patch
+0009-Rename-x-webview-native-view-to-webview.patch

--- a/src/patches/lynx/0009-Rename-x-webview-native-view-to-webview.patch
+++ b/src/patches/lynx/0009-Rename-x-webview-native-view-to-webview.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zsy-jason <186247581+zsy-jason@users.noreply.github.com>
+Date: Thu, 28 Aug 2026 00:00:00 +0000
+Subject: [PATCH] Rename x-webview native view to webview
+
+diff --git a/platform/embedder/plugin/cef/src/cef_extension_module.cc b/platform/embedder/plugin/cef/src/cef_extension_module.cc
+index 000000000..000000000 100644
+--- a/platform/embedder/plugin/cef/src/cef_extension_module.cc
++++ b/platform/embedder/plugin/cef/src/cef_extension_module.cc
+@@ -21,8 +21,8 @@ namespace embedder {
+ 
+ void CEFExtensionModule::OnLynxViewCreate(lynx_view_t* lynx_view) {
+   LYNX_CAPI_TRACE_BEGIN(CEF_TRACE_CATEGORY, TRACE_NAME_REGISTER_VIEW);
+-  lynx_view_register_native_view(lynx_view, "x-webview",
+-                                 &cef_webview_create_view, lynx_view);
++  lynx_view_register_native_view(lynx_view, "webview",
++                                 &cef_webview_create_view, lynx_view);
+   LYNX_CAPI_TRACE_END(CEF_TRACE_CATEGORY, TRACE_NAME_REGISTER_VIEW);
+ }
+ 


### PR DESCRIPTION
- Add x64 architecture to macOS build matrices (release, dev, cef-webview)
- Add patch to rename CEF native view registration from "x-webview" to "webview"