### PR TITLE
[Infra] Make Habitat syncs resilient

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,7 @@ jobs:
     timeout-minutes: 120
     runs-on: lynx-darwin-15.6.1-medium
     strategy:
+      fail-fast: false
       matrix:
         arch: [arm64, x64]
     steps:
@@ -530,6 +531,7 @@ jobs:
     timeout-minutes: 120
     runs-on: lynx-darwin-15.6.1-medium
     strategy:
+      fail-fast: false
       matrix:
         arch: [arm64, x64]
     steps:
@@ -538,10 +540,16 @@ jobs:
         with:
           path: lynxtron
           ref: ${{ github.ref_name }}
+      - name: Install Common Dependencies
+        uses: ./lynxtron/.github/actions/common-deps
+        with:
+          run-habitat-sync: 'false'
       - name: Prepare environment
         shell: bash
+        env:
+          HABITAT_CONCURRENCY: 2
         run: |
-          set -x
+          set -euxo pipefail
           cd ${{ github.workspace }}/lynxtron
           git config --global http.version HTTP/1.1
           git config --global user.name "Lynxtron Scripts"
@@ -552,7 +560,18 @@ jobs:
           python3 setup_deps.py
           # Sync CEF binary distribution required by cef-webview CMakeLists.
           cd ${{ github.workspace }}/lynxtron/src
-          "${{ github.workspace }}/lynxtron/lynxtron_tools/hab" sync . -f --no-history --target extension --target-only
+          for attempt in 1 2 3; do
+            if "${{ github.workspace }}/lynxtron/lynxtron_tools/hab" sync . -f --no-history --target extension --target-only; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "sync CEF extension dependencies failed after 3 attempts"
+              exit 1
+            fi
+            delay=$((10 * (2 ** (attempt - 1))))
+            echo "sync CEF extension dependencies failed (attempt $attempt/3); retrying in $delay seconds..."
+            sleep "$delay"
+          done
       - uses: actions/setup-node@v4
         with:
           node-version: 24.14.1

--- a/lynxtron_tools/prepare_build_env.py
+++ b/lynxtron_tools/prepare_build_env.py
@@ -4,12 +4,17 @@
 import os
 import platform
 import sys
+import time
 
 COLORED_YELLOW_MSG = '\033[33m'
 COLORED_RED_MSG = '\033[31m'
 COLORED_GREEN_MSG = '\033[32m'
 
 COLORED_PRINT_END = '\033[0m'
+
+HABITAT_CONCURRENCY = "2"
+HABITAT_SYNC_ATTEMPTS = 3
+HABITAT_RETRY_BASE_DELAY_SECONDS = 10
 
 # Get the directory where the current script is located
 current_dir = os.path.dirname(os.path.realpath(__file__))
@@ -20,6 +25,34 @@ sys.path.append(root_dir)
 from src.script.abort_am_sessions import abort_am_sessions
 src_dir = os.path.join(root_dir, "src")
 print(f"src_dir: {src_dir}")
+
+
+def run_habitat_sync(command, description):
+    """Run a Habitat sync with bounded exponential-backoff retries."""
+    return_code = 0
+    for attempt in range(1, HABITAT_SYNC_ATTEMPTS + 1):
+        return_code = os.system(command)
+        if return_code == 0:
+            return 0
+        if attempt < HABITAT_SYNC_ATTEMPTS:
+            delay = HABITAT_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+            print(
+                f"{COLORED_YELLOW_MSG}{description} failed "
+                f"(attempt {attempt}/{HABITAT_SYNC_ATTEMPTS}, return_code={return_code}); "
+                f"retrying in {delay} seconds...{COLORED_PRINT_END}"
+            )
+            time.sleep(delay)
+    print(
+        f"{COLORED_RED_MSG}{description} failed after "
+        f"{HABITAT_SYNC_ATTEMPTS} attempts{COLORED_PRINT_END}"
+    )
+    return return_code
+
+
+def configure_habitat_environment():
+    os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"
+    os.environ["HABITAT_CONCURRENCY"] = HABITAT_CONCURRENCY
+
 
 def main():
     start_cwd = os.getcwd()
@@ -34,7 +67,7 @@ def main():
         envsetup = f"source {envsetup_file}"
         python3 = "python3"
 
-    os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"
+    configure_habitat_environment()
     print(f"{COLORED_YELLOW_MSG}hab: {hab}{COLORED_PRINT_END}")
     print(f"{COLORED_YELLOW_MSG}envsetup: {envsetup}{COLORED_PRINT_END}")
     print(f"{COLORED_GREEN_MSG}abort am sessions............{COLORED_PRINT_END}")
@@ -42,24 +75,27 @@ def main():
     print(f"{COLORED_YELLOW_MSG}sync lynxtron dependencies............{COLORED_PRINT_END}")
     os.chdir(src_dir)
     if system == "windows":
-        return_code = os.system(f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history --target lynxtron")
+        sync_lynxtron_cmd = f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history --target lynxtron"
     else:
-        return_code = os.system(f"\"{hab}\" sync . -f --no-history --target lynxtron")
+        sync_lynxtron_cmd = f"\"{hab}\" sync . -f --no-history --target lynxtron"
+    return_code = run_habitat_sync(sync_lynxtron_cmd, "sync lynxtron dependencies")
     if return_code != 0:
         print(f"{COLORED_YELLOW_MSG}sync lynxtron dependencies failed, exit{COLORED_PRINT_END}")
         return return_code
     print(f"{COLORED_YELLOW_MSG}sync tools dependencies............{COLORED_PRINT_END}")
     if system == "windows":
-        return_code = os.system(f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history --target tools --target-only")
+        sync_tools_cmd = f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history --target tools --target-only"
     else:
-        return_code = os.system(f"\"{hab}\" sync . -f --no-history --target tools --target-only")
+        sync_tools_cmd = f"\"{hab}\" sync . -f --no-history --target tools --target-only"
+    return_code = run_habitat_sync(sync_tools_cmd, "sync tools dependencies")
     if return_code != 0:
         print(f"{COLORED_YELLOW_MSG}sync tools dependencies failed, exit{COLORED_PRINT_END}")
         return return_code
     if system == "windows":
-        return_code = os.system(f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history --target tools_shared --target-only")
+        sync_tools_shared_cmd = f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history --target tools_shared --target-only"
     else:
-        return_code = os.system(f"\"{hab}\" sync . -f --no-history --target tools_shared --target-only")
+        sync_tools_shared_cmd = f"\"{hab}\" sync . -f --no-history --target tools_shared --target-only"
+    return_code = run_habitat_sync(sync_tools_shared_cmd, "sync tools_shared dependencies")
     if return_code != 0:
         print(f"{COLORED_YELLOW_MSG}sync tools_shared dependencies failed, exit{COLORED_PRINT_END}")
         return return_code
@@ -68,23 +104,9 @@ def main():
         lynx_sync_cmd = f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history --target lynx --target-only"
     else:
         lynx_sync_cmd = f"\"{hab}\" sync . -f --no-history --target lynx --target-only"
-    # The lynx repo is large, so the first sync occasionally fails
-    # (network / lock / path race). Retry at most once before giving up.
-    max_attempts = 2
-    for attempt in range(max_attempts):
-        if attempt > 0:
-            print(
-                f"{COLORED_YELLOW_MSG}retry sync lynx dependencies (attempt {attempt + 1}/{max_attempts})............{COLORED_PRINT_END}"
-            )
-        return_code = os.system(lynx_sync_cmd)
-        if return_code == 0:
-            break
-        if attempt + 1 < max_attempts:
-            print(
-                f"{COLORED_YELLOW_MSG}sync lynx dependencies failed (return_code={return_code}), will retry...{COLORED_PRINT_END}"
-            )
+    return_code = run_habitat_sync(lynx_sync_cmd, "sync lynx dependencies")
     if return_code != 0:
-        print(f"{COLORED_RED_MSG}sync lynx dependencies failed after retry, exit{COLORED_PRINT_END}")
+        print(f"{COLORED_RED_MSG}sync lynx dependencies failed, exit{COLORED_PRINT_END}")
         return return_code
 
     if system == "windows":
@@ -93,8 +115,9 @@ def main():
         try:
             os.chdir(skity_dir)
             print(f"{COLORED_YELLOW_MSG}sync skity dependencies............{COLORED_PRINT_END}")
-            return_code = os.system(
-                f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history"
+            return_code = run_habitat_sync(
+                f"powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File \"{hab}\" sync . -f --no-history",
+                "sync skity dependencies",
             )
             if return_code != 0:
                 print(f"{COLORED_RED_MSG}sync skity dependencies failed, exit{COLORED_PRINT_END}")

--- a/lynxtron_tools/test_prepare_build_env.py
+++ b/lynxtron_tools/test_prepare_build_env.py
@@ -1,0 +1,59 @@
+# Copyright 2026 The Lynxtron Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+from unittest import mock
+
+from lynxtron_tools import prepare_build_env
+
+
+class RunHabitatSyncTest(unittest.TestCase):
+
+    def test_configures_two_concurrent_habitat_requests(self):
+        with mock.patch.dict(
+            prepare_build_env.os.environ,
+            {"HABITAT_CONCURRENCY": "99"},
+        ):
+            prepare_build_env.configure_habitat_environment()
+
+            self.assertEqual(
+                prepare_build_env.os.environ["HABITAT_CONCURRENCY"], "2"
+            )
+            self.assertEqual(
+                prepare_build_env.os.environ["GIT_LFS_SKIP_SMUDGE"], "1"
+            )
+
+    @mock.patch.object(prepare_build_env.time, "sleep")
+    @mock.patch.object(prepare_build_env.os, "system", side_effect=[1, 2, 0])
+    def test_retries_three_times_with_exponential_backoff(
+        self, system_mock, sleep_mock
+    ):
+        result = prepare_build_env.run_habitat_sync("hab sync", "sync test")
+
+        self.assertEqual(result, 0)
+        self.assertEqual(system_mock.call_count, 3)
+        sleep_mock.assert_has_calls([mock.call(10), mock.call(20)])
+
+    @mock.patch.object(prepare_build_env.time, "sleep")
+    @mock.patch.object(prepare_build_env.os, "system", return_value=7)
+    def test_returns_last_failure_after_three_attempts(
+        self, system_mock, sleep_mock
+    ):
+        result = prepare_build_env.run_habitat_sync("hab sync", "sync test")
+
+        self.assertEqual(result, 7)
+        self.assertEqual(system_mock.call_count, 3)
+        sleep_mock.assert_has_calls([mock.call(10), mock.call(20)])
+
+    @mock.patch.object(prepare_build_env.time, "sleep")
+    @mock.patch.object(prepare_build_env.os, "system", return_value=0)
+    def test_does_not_retry_success(self, system_mock, sleep_mock):
+        result = prepare_build_env.run_habitat_sync("hab sync", "sync test")
+
+        self.assertEqual(result, 0)
+        system_mock.assert_called_once_with("hab sync")
+        sleep_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/packages/lynxtron-builder/test/publish-workflow.test.js
+++ b/src/packages/lynxtron-builder/test/publish-workflow.test.js
@@ -110,6 +110,23 @@ test('macOS releases publish both universal slice architectures', () => {
   );
 });
 
+test('macOS publish jobs preserve sibling architectures and cache CEF dependencies', () => {
+  assert.equal(jobs['build-macos'].strategy['fail-fast'], false);
+  assert.equal(jobs['build-cef-webview-macos'].strategy['fail-fast'], false);
+
+  const cefJob = jobs['build-cef-webview-macos'];
+  const cacheStep = cefJob.steps.find(
+    (step) => step.uses === './lynxtron/.github/actions/common-deps'
+  );
+  assert.ok(cacheStep, 'CEF builds must restore and save the Habitat cache');
+  assert.equal(cacheStep.with['run-habitat-sync'], 'false');
+
+  const prepareStep = cefJob.steps.find((step) => step.name === 'Prepare environment');
+  assert.equal(prepareStep.env.HABITAT_CONCURRENCY, 2);
+  assert.match(prepareStep.run, /for attempt in 1 2 3/);
+  assert.match(prepareStep.run, /10 \* \(2 \*\* \(attempt - 1\)\)/);
+});
+
 test('pull request CI builds every published architecture', () => {
   assert.deepEqual(
     new Set(ciJobs['macos-lynxtron-build'].strategy.matrix.arch),


### PR DESCRIPTION
## Summary
- retry every Habitat sync up to three times with 10s/20s exponential backoff
- cap actual Habitat sync concurrency at 2
- restore/save Habitat cache for CEF builds and retry extension syncs
- disable fail-fast for macOS release and CEF architecture matrices

## Tests
- `python3 -m unittest -v lynxtron_tools.test_prepare_build_env` (4 passed)
- `npm --prefix src/packages/lynxtron-builder test` (25 passed)
- `git diff --check`