### PR TITLE
[Infra] Make Windows resource compiler selection deterministic

### DIFF
--- a/.github/actions/windows-lynxtron-build/action.yml
+++ b/.github/actions/windows-lynxtron-build/action.yml
@@ -57,6 +57,25 @@ runs:
         cd ${{ github.workspace }}/lynxtron
         .\lynxtron_tools\envsetup.ps1
         $env:PATH = "$pwd\buildtools\gn;$pwd\buildtools\ninja;$pwd\buildtools\sccache;$env:PATH"
+
+        # envsetup puts Habitat's pinned resource compiler first in PATH. Validate
+        # that setup before the expensive build instead of failing late in Ninja.
+        $resourceCompiler = Join-Path $pwd 'build\toolchain\win\rc\win\rc.exe'
+        if (-not (Test-Path -LiteralPath $resourceCompiler -PathType Leaf)) {
+          throw "Hermetic Windows resource compiler was not downloaded: $resourceCompiler"
+        }
+        $expectedResourceCompiler = [System.IO.Path]::GetFullPath($resourceCompiler)
+        $resolvedResourceCompiler = [System.IO.Path]::GetFullPath(
+          (Get-Command rc.exe -CommandType Application -ErrorAction Stop).Source
+        )
+        if (-not $resolvedResourceCompiler.Equals(
+          $expectedResourceCompiler,
+          [System.StringComparison]::OrdinalIgnoreCase
+        )) {
+          throw "Expected rc.exe at $expectedResourceCompiler, resolved $resolvedResourceCompiler"
+        }
+        Write-Host "Using Windows resource compiler: $resolvedResourceCompiler"
+
         $gnExtraArgs = @()
         if ('${{ inputs.enable-inspector }}' -eq 'true') {
           $gnExtraArgs += '--enable-inspector'

--- a/lynxtron_tools/envsetup.ps1
+++ b/lynxtron_tools/envsetup.ps1
@@ -14,6 +14,16 @@ function Lynxtron-Env-Setup {
     $env:PATH += Join-Path $buildtoolsDir 'gn;'
     $env:PATH += Join-Path $buildtoolsDir 'ninja;'
     $env:PATH += Join-Path $buildtoolsDir 'sccache;'
+
+    # Habitat syncs Chromium's pinned resource compiler into the repository.
+    # Prefer it over a runner- or machine-provided Windows SDK copy so GN's
+    # bare `rc.exe` invocation is deterministic.
+    $resourceCompiler = Join-Path $lynxtron_dir_path 'build\toolchain\win\rc\win\rc.exe'
+    if (Test-Path -LiteralPath $resourceCompiler -PathType Leaf) {
+        $resourceCompilerDir = Split-Path -Parent $resourceCompiler
+        $env:PATH = "$resourceCompilerDir;$env:PATH"
+        Write-Host "resourceCompilerDir: " $resourceCompilerDir
+    }
 }
 
 function Python-Env-Setup {

--- a/src/packages/lynxtron-builder/test/publish-workflow.test.js
+++ b/src/packages/lynxtron-builder/test/publish-workflow.test.js
@@ -10,6 +10,17 @@ const workflow = yaml.load(workflowSource);
 const { jobs } = workflow;
 const ciWorkflowPath = path.resolve(__dirname, '../../../../.github/workflows/ci.yml');
 const ciJobs = yaml.load(fs.readFileSync(ciWorkflowPath, 'utf8')).jobs;
+const windowsBuildActionPath = path.resolve(
+  __dirname,
+  '../../../../.github/actions/windows-lynxtron-build/action.yml'
+);
+const windowsBuildAction = yaml.load(
+  fs.readFileSync(windowsBuildActionPath, 'utf8')
+);
+const windowsEnvSetupSource = fs.readFileSync(
+  path.resolve(__dirname, '../../../../lynxtron_tools/envsetup.ps1'),
+  'utf8'
+);
 
 test('one version and one release gate both runtime variants', () => {
   assert.deepEqual(Object.keys(jobs['get-version'].outputs).sort(), ['tag', 'version']);
@@ -134,6 +145,28 @@ test('pull request CI builds every published architecture', () => {
   );
   assert.deepEqual(ciJobs['linux-lynxtron-build'].strategy.matrix.arch, ['x64']);
   assert.deepEqual(ciJobs['windows-lynxtron-build'].strategy.matrix.arch, ['x64']);
+});
+
+test('Windows builds use and validate the pinned resource compiler', () => {
+  const buildStep = windowsBuildAction.runs.steps.find(
+    (step) => step.name === 'Build Lynxtron'
+  );
+  const buildScript = buildStep.run;
+  const compilerPath = 'build\\toolchain\\win\\rc\\win\\rc.exe';
+
+  assert.ok(windowsEnvSetupSource.includes(compilerPath));
+  assert.match(windowsEnvSetupSource, /Test-Path -LiteralPath \$resourceCompiler -PathType Leaf/);
+  assert.match(windowsEnvSetupSource, /\$env:PATH = "\$resourceCompilerDir;\$env:PATH"/);
+
+  assert.ok(buildScript.includes(compilerPath));
+  assert.match(buildScript, /Test-Path -LiteralPath \$resourceCompiler -PathType Leaf/);
+  assert.match(buildScript, /Get-Command rc\.exe -CommandType Application -ErrorAction Stop/);
+  assert.match(buildScript, /StringComparison\]::OrdinalIgnoreCase/);
+  assert.ok(
+    buildScript.indexOf('Get-Command rc.exe') <
+      buildScript.indexOf('ninja.exe -C out\\Release lynxtron_app'),
+    'resource compiler validation must run before the expensive build'
+  );
 });
 
 test('npm packages are published once without a legacy dev release channel', () => {


### PR DESCRIPTION
## Summary

- prepend the Chromium-pinned resource compiler downloaded by Habitat to PATH during Windows environment setup
- validate before GN/Ninja that rc.exe resolves to that pinned executable
- add a regression test covering the environment setup and fail-fast validation

## Context

The first Windows DevTool attempt in workflow run 33726161212 failed at 6876/8701 because rc.exe could not be found. A retry of the same commit succeeded on another runner, showing that the build depended on runner-specific Windows SDK PATH configuration.

## Tests

- node --test src/packages/lynxtron-builder/test/*.test.js (26 passed)
- python3 -m unittest lynxtron_tools.test_prepare_build_env (4 passed)
- git diff --check