### PR TITLE
[Infra] Add alpha and Changesets release workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,16 @@
 name: publish
 
 on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: 'branch, tag, or commit to publish'
+        required: true
+        type: string
+      tag:
+        description: 'release tag'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       source_ref:
@@ -24,7 +34,8 @@ jobs:
       run:
         working-directory: ./
     env:
-      INPUT_TAG: ${{ github.event.inputs.tag }}
+      INPUT_TAG: ${{ inputs.tag }}
+      TRIGGER_EVENT: ${{ github.event_name }}
     outputs:
       source_sha: ${{ steps.set-version.outputs.source_sha }}
       version: ${{ steps.set-version.outputs.version }}
@@ -35,7 +46,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: source
-          ref: ${{ github.event.inputs.source_ref }}
+          ref: ${{ inputs.source_ref }}
           fetch-depth: 1
       - name: Validate and set version
         id: set-version
@@ -61,6 +72,18 @@ jobs:
             *-*) prerelease=true ;;
             *) prerelease=false ;;
           esac
+          if [ "$TRIGGER_EVENT" = "workflow_dispatch" ]; then
+            case "$version" in
+              *-alpha|*-alpha.*) ;;
+              *)
+                echo "manually dispatched branch releases must use an alpha version (e.g. v1.2.3-alpha.0)"
+                exit 1
+                ;;
+            esac
+          elif [ "$prerelease" = "true" ]; then
+            echo "Changesets releases from main must use a stable version; got '$version'"
+            exit 1
+          fi
           source_sha=$(git -C source rev-parse HEAD)
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,13 @@ name: publish
 on:
   workflow_dispatch:
     inputs:
+      source_ref:
+        description: 'branch, tag, or commit to publish (e.g. feature/my-change)'
+        required: true
+        default: main
+        type: string
       tag:
-        description: 'release tag (e.g. v1.2.3). Release and DevTool runtimes are published together.'
+        description: 'release tag (e.g. v1.2.3-alpha.0). Release and DevTool runtimes are published together.'
         required: true
         type: string
 
@@ -21,26 +26,46 @@ jobs:
     env:
       INPUT_TAG: ${{ github.event.inputs.tag }}
     outputs:
+      source_sha: ${{ steps.set-version.outputs.source_sha }}
       version: ${{ steps.set-version.outputs.version }}
       tag: ${{ steps.set-version.outputs.tag }}
+      prerelease: ${{ steps.set-version.outputs.prerelease }}
     steps:
+      - name: Resolve source revision
+        uses: actions/checkout@v4.2.2
+        with:
+          path: source
+          ref: ${{ github.event.inputs.source_ref }}
+          fetch-depth: 1
       - name: Validate and set version
         id: set-version
         run: |
+          set -eu
           if [ -z "$INPUT_TAG" ]; then
             echo "tag input is required."
             exit 1
           fi
           tag="v${INPUT_TAG#v}"
           version="${tag#v}"
+          if ! printf '%s\n' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
+            echo "tag must contain a valid semantic version; got '$INPUT_TAG'"
+            exit 1
+          fi
           case "$version" in
             *-dev|*-dev.*)
               echo "tag must not include a '-dev' pre-release label; use a regular version because Release and DevTool runtimes are published together"
               exit 1
               ;;
           esac
+          case "$version" in
+            *-*) prerelease=true ;;
+            *) prerelease=false ;;
+          esac
+          source_sha=$(git -C source rev-parse HEAD)
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
 
   build-macos:
     needs: get-version
@@ -55,7 +80,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynxtron
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.get-version.outputs.source_sha }}
       - name: Build macOS Lynxtron
         uses: ./lynxtron/.github/actions/macos-lynxtron-build
         with:
@@ -136,7 +161,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynxtron
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.get-version.outputs.source_sha }}
       - name: Build Linux Lynxtron
         uses: ./lynxtron/.github/actions/linux-lynxtron-build
         with:
@@ -222,7 +247,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynxtron
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.get-version.outputs.source_sha }}
       - name: Build Windows Lynxtron
         uses: ./lynxtron/.github/actions/windows-lynxtron-build
         with:
@@ -313,7 +338,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynxtron
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.get-version.outputs.source_sha }}
       - name: Build macOS Lynxtron (DevTool)
         uses: ./lynxtron/.github/actions/macos-lynxtron-build
         with:
@@ -374,7 +399,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynxtron
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.get-version.outputs.source_sha }}
       - name: Build Linux Lynxtron (DevTool)
         uses: ./lynxtron/.github/actions/linux-lynxtron-build
         with:
@@ -461,7 +486,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynxtron
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.get-version.outputs.source_sha }}
       - name: Build Windows Lynxtron (DevTool)
         uses: ./lynxtron/.github/actions/windows-lynxtron-build
         with:
@@ -539,7 +564,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynxtron
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.get-version.outputs.source_sha }}
       - name: Install Common Dependencies
         uses: ./lynxtron/.github/actions/common-deps
         with:
@@ -650,7 +675,9 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.get-version.outputs.tag }}
+          commit: ${{ needs.get-version.outputs.source_sha }}
           name: Release ${{ needs.get-version.outputs.tag }}
+          prerelease: ${{ needs.get-version.outputs.prerelease == 'true' }}
           generateReleaseNotes: true
           allowUpdates: true
           artifactErrorsFailBuild: true
@@ -670,7 +697,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynxtron
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.get-version.outputs.source_sha }}
       - name: Python Setup
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: changesets release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: changesets-release-main
+  cancel-in-progress: false
+
+jobs:
+  changesets:
+    runs-on: lynx-ubuntu-22.04-medium
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      should_publish: ${{ steps.release.outputs.should_publish }}
+      source_sha: ${{ steps.release.outputs.source_sha }}
+      tag: ${{ steps.release.outputs.tag }}
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
+        working-directory: src
+        run: node tools/yarn.js install --immutable --mode=skip-build
+      - name: Create or update Version Packages pull request
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          cwd: src
+          version: node tools/yarn.js version-packages
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
+      - name: Select stable release
+        id: release
+        shell: bash
+        env:
+          HAS_CHANGESETS: ${{ steps.changesets.outputs.hasChangesets }}
+        run: |
+          set -euo pipefail
+
+          if [ "$HAS_CHANGESETS" != "false" ]; then
+            echo "Changesets are pending; the Version Packages pull request will be created or updated."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          version=$(node -p "require('./src/packages/lynxtron/package.json').version")
+          if ! printf '%s\n' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Changesets stable release version is invalid: '$version'"
+            exit 1
+          fi
+
+          for package_dir in \
+            cef-webview \
+            create-lynxtron \
+            lynx-library-headers \
+            lynxtron \
+            lynxtron-builder \
+            lynxtron-dev-plugins \
+            lynxtron-rebuild; do
+            package_version=$(node -p "require('./src/packages/${package_dir}/package.json').version")
+            if [ "$package_version" != "$version" ]; then
+              echo "Published package versions must stay fixed: ${package_dir} has ${package_version}, expected ${version}"
+              exit 1
+            fi
+          done
+
+          tag="v${version}"
+          if git show-ref --verify --quiet "refs/tags/${tag}"; then
+            echo "${tag} is already published; skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "source_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: changesets
+    if: needs.changesets.outputs.should_publish == 'true'
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/publish.yml
+    with:
+      source_ref: ${{ needs.changesets.outputs.source_sha }}
+      tag: ${{ needs.changesets.outputs.tag }}
+    secrets: inherit

--- a/src/.changeset/README.md
+++ b/src/.changeset/README.md
@@ -1,5 +1,10 @@
 This folder contains your Changesets.
 
 Create a new changeset with `yarn changeset` and follow the prompts.
-After merging changesets into `main`, run `yarn version-packages` to update package versions and changelogs.
-Publish with `yarn release`.
+After changesets are merged into `main`, the Changesets release workflow creates
+or updates a Version Packages pull request. Merging that pull request publishes
+the stable runtime and npm packages from the merge commit.
+
+Alpha releases do not consume changesets. Run the `publish` workflow manually,
+provide the source branch in `source_ref`, and use an alpha tag such as
+`v1.2.3-alpha.0`.

--- a/src/.changeset/config.json
+++ b/src/.changeset/config.json
@@ -1,8 +1,19 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
-  "changelog": "@changesets/cli",
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "access": "public",
   "baseBranch": "main",
+  "fixed": [
+    [
+      "@lynx-js/cef-webview",
+      "@lynx-js/lynx-library-headers",
+      "@lynx-js/lynxtron",
+      "@lynx-js/lynxtron-builder",
+      "@lynx-js/lynxtron-dev-plugins",
+      "@lynx-js/lynxtron-rebuild",
+      "create-lynxtron"
+    ]
+  ],
   "ignore": ["lynxtron-shell-demo", "lynxtron-default-app"]
 }

--- a/src/package.json
+++ b/src/package.json
@@ -40,10 +40,12 @@
   ],
   "workspaces": [
     "packages/default_app/app",
+    "packages/cef-webview",
     "packages/lynxtron",
     "packages/lynxtron-builder",
     "packages/lynxtron-shell-demo",
     "packages/lynxtron-dev-plugins",
+    "packages/lynxtron-rebuild",
     "packages/create-lynxtron",
     "spec/case/lynx-card",
     "packages/lynx-library-headers"

--- a/src/packages/cef-webview/package.json
+++ b/src/packages/cef-webview/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lynx-js/cef-webview",
   "author": "Lynxtron Authors",
-  "version": "0.0.1",
+  "version": "0.0.18",
   "type": "module",
   "description": "a webview element based on cef",
   "repository": {
@@ -37,9 +37,9 @@
     "zip-lib": "1.4.0"
   },
   "devDependencies": {
-    "node-addon-api": "^7.0.0",
+    "@lynx-js/lynxtron": "workspace:*",
     "cmake-js": "^7.4.0",
-    "@lynx-js/lynxtron": "*"
+    "node-addon-api": "^7.0.0"
   },
   "engines": {
     "node": "^22.18.0 || ^24.0.0 || ^26.0.0"

--- a/src/packages/create-lynxtron/package.json
+++ b/src/packages/create-lynxtron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-lynxtron",
-  "version": "0.0.0-alpha.12",
+  "version": "0.0.18",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/packages/lynx-library-headers/package.json
+++ b/src/packages/lynx-library-headers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lynx-js/lynx-library-headers",
   "author": "Lynxtron Authors",
-  "version": "0.0.1",
+  "version": "0.0.18",
   "type": "module",
   "description": "Lynx embedder C/C++ API and weak N-API headers for native libraries",
   "repository": {

--- a/src/packages/lynxtron-builder/package.json
+++ b/src/packages/lynxtron-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/lynxtron-builder",
-  "version": "0.0.0-alpha",
+  "version": "0.0.18",
   "main": "cli.js",
   "repository": {
     "type": "git",

--- a/src/packages/lynxtron-builder/test/publish-workflow.test.js
+++ b/src/packages/lynxtron-builder/test/publish-workflow.test.js
@@ -8,6 +8,21 @@ const workflowPath = path.resolve(__dirname, '../../../../.github/workflows/publ
 const workflowSource = fs.readFileSync(workflowPath, 'utf8');
 const workflow = yaml.load(workflowSource);
 const { jobs } = workflow;
+const releaseWorkflowPath = path.resolve(
+  __dirname,
+  '../../../../.github/workflows/release.yml'
+);
+const releaseWorkflow = yaml.load(fs.readFileSync(releaseWorkflowPath, 'utf8'));
+const changesetConfig = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../.changeset/config.json'), 'utf8')
+);
+const workspacePackage = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8')
+);
+const publishPrepareSource = fs.readFileSync(
+  path.resolve(__dirname, '../../publish_prepare.py'),
+  'utf8'
+);
 const ciWorkflowPath = path.resolve(__dirname, '../../../../.github/workflows/ci.yml');
 const ciJobs = yaml.load(fs.readFileSync(ciWorkflowPath, 'utf8')).jobs;
 const windowsBuildActionPath = path.resolve(
@@ -54,7 +69,7 @@ test('every publish job uses the immutable revision resolved from the requested 
   const resolveStep = jobs['get-version'].steps.find(
     (step) => step.name === 'Resolve source revision'
   );
-  assert.equal(resolveStep.with.ref, '${{ github.event.inputs.source_ref }}');
+  assert.equal(resolveStep.with.ref, '${{ inputs.source_ref }}');
 
   const checkoutJobs = [
     'build-macos',
@@ -84,6 +99,92 @@ test('every publish job uses the immutable revision resolved from the requested 
   assert.equal(
     releaseStep.with.prerelease,
     "${{ needs.get-version.outputs.prerelease == 'true' }}"
+  );
+});
+
+test('manual publishes are alpha-only while reusable publishes are stable-only', () => {
+  assert.ok(workflow.on.workflow_call);
+  assert.ok(workflow.on.workflow_dispatch);
+
+  const versionScript = jobs['get-version'].steps.find(
+    (step) => step.name === 'Validate and set version'
+  ).run;
+  assert.match(versionScript, /manually dispatched branch releases must use an alpha version/);
+  assert.match(versionScript, /Changesets releases from main must use a stable version/);
+});
+
+test('Changesets creates a version PR and publishes an unpublished stable version from main', () => {
+  assert.deepEqual(releaseWorkflow.on.push.branches, ['main']);
+
+  const changesetJob = releaseWorkflow.jobs.changesets;
+  const actionStep = changesetJob.steps.find(
+    (step) => step.uses === 'changesets/action@v1'
+  );
+  assert.equal(actionStep.id, 'changesets');
+  assert.equal(actionStep.with.cwd, 'src');
+  assert.equal(actionStep.with.version, 'node tools/yarn.js version-packages');
+
+  const releaseStep = changesetJob.steps.find(
+    (step) => step.name === 'Select stable release'
+  );
+  assert.equal(
+    releaseStep.env.HAS_CHANGESETS,
+    '${{ steps.changesets.outputs.hasChangesets }}'
+  );
+  assert.match(releaseStep.run, /HAS_CHANGESETS.*!=.*false/);
+  assert.match(releaseStep.run, /refs\/tags\/\$\{tag\}/);
+  assert.match(releaseStep.run, /source_sha=\$\{GITHUB_SHA\}/);
+
+  const publishJob = releaseWorkflow.jobs.publish;
+  assert.equal(publishJob.uses, './.github/workflows/publish.yml');
+  assert.equal(
+    publishJob.with.source_ref,
+    '${{ needs.changesets.outputs.source_sha }}'
+  );
+  assert.equal(publishJob.with.tag, '${{ needs.changesets.outputs.tag }}');
+});
+
+test('all packages published by the runtime workflow use one Changesets version', () => {
+  const publishedPackageDirs = [
+    'cef-webview',
+    'create-lynxtron',
+    'lynx-library-headers',
+    'lynxtron',
+    'lynxtron-builder',
+    'lynxtron-dev-plugins',
+    'lynxtron-rebuild',
+  ];
+  assert.equal(changesetConfig.changelog, '@changesets/cli/changelog');
+  assert.deepEqual(changesetConfig.fixed, [[
+    '@lynx-js/cef-webview',
+    '@lynx-js/lynx-library-headers',
+    '@lynx-js/lynxtron',
+    '@lynx-js/lynxtron-builder',
+    '@lynx-js/lynxtron-dev-plugins',
+    '@lynx-js/lynxtron-rebuild',
+    'create-lynxtron',
+  ]]);
+  assert.ok(workspacePackage.workspaces.includes('packages/cef-webview'));
+  assert.ok(workspacePackage.workspaces.includes('packages/lynxtron-rebuild'));
+
+  const publishedVersions = publishedPackageDirs.map((packageDir) => {
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.resolve(__dirname, `../../${packageDir}/package.json`),
+        'utf8'
+      )
+    );
+    return manifest.version;
+  });
+  assert.equal(new Set(publishedVersions).size, 1);
+
+  const cefManifest = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../../cef-webview/package.json'), 'utf8')
+  );
+  assert.equal(cefManifest.devDependencies['@lynx-js/lynxtron'], 'workspace:*');
+  assert.match(
+    publishPrepareSource,
+    /"cef-webview"[\s\S]*?"replaces"[\s\S]*?"@lynx-js\/lynxtron"/
   );
 });
 

--- a/src/packages/lynxtron-builder/test/publish-workflow.test.js
+++ b/src/packages/lynxtron-builder/test/publish-workflow.test.js
@@ -23,7 +23,12 @@ const windowsEnvSetupSource = fs.readFileSync(
 );
 
 test('one version and one release gate both runtime variants', () => {
-  assert.deepEqual(Object.keys(jobs['get-version'].outputs).sort(), ['tag', 'version']);
+  assert.deepEqual(Object.keys(jobs['get-version'].outputs).sort(), [
+    'prerelease',
+    'source_sha',
+    'tag',
+    'version',
+  ]);
   assert.equal(jobs['create-release-dev'], undefined);
   assert.equal(jobs['publish-npm-dev'], undefined);
   assert.deepEqual(
@@ -38,6 +43,47 @@ test('one version and one release gate both runtime variants', () => {
       'build-linux-devtool',
       'build-windows-devtool',
     ])
+  );
+});
+
+test('every publish job uses the immutable revision resolved from the requested source ref', () => {
+  const sourceInput = workflow.on.workflow_dispatch.inputs.source_ref;
+  assert.equal(sourceInput.required, true);
+  assert.equal(sourceInput.default, 'main');
+
+  const resolveStep = jobs['get-version'].steps.find(
+    (step) => step.name === 'Resolve source revision'
+  );
+  assert.equal(resolveStep.with.ref, '${{ github.event.inputs.source_ref }}');
+
+  const checkoutJobs = [
+    'build-macos',
+    'build-linux',
+    'build-windows',
+    'build-macos-devtool',
+    'build-linux-devtool',
+    'build-windows-devtool',
+    'build-cef-webview-macos',
+    'publish-npm',
+  ];
+  for (const jobName of checkoutJobs) {
+    const checkoutStep = jobs[jobName].steps.find(
+      (step) => step.uses === 'actions/checkout@v4.2.2'
+    );
+    assert.equal(
+      checkoutStep.with.ref,
+      '${{ needs.get-version.outputs.source_sha }}',
+      `${jobName} must checkout the resolved source revision`
+    );
+  }
+
+  const releaseStep = jobs['create-release'].steps.find(
+    (step) => step.uses === 'ncipollo/release-action@v1'
+  );
+  assert.equal(releaseStep.with.commit, '${{ needs.get-version.outputs.source_sha }}');
+  assert.equal(
+    releaseStep.with.prerelease,
+    "${{ needs.get-version.outputs.prerelease == 'true' }}"
   );
 });
 

--- a/src/packages/lynxtron-dev-plugins/package.json
+++ b/src/packages/lynxtron-dev-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/lynxtron-dev-plugins",
-  "version": "0.0.0-alpha.8",
+  "version": "0.0.18",
   "type": "module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/packages/lynxtron-rebuild/package.json
+++ b/src/packages/lynxtron-rebuild/package.json
@@ -1,15 +1,13 @@
 {
   "name": "@lynx-js/lynxtron-rebuild",
-  "version": "0.0.0-alpha",
+  "version": "0.0.18",
   "description": "Rebuild native modules for Lynxtron",
   "main": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/lynx-family/lynxtron.git"
   },
-  "bin": {
-    "lynxtron-rebuild": "bin/lynxtron-rebuild.js"
-  },
+  "bin": "bin/lynxtron-rebuild.js",
   "type": "module",
   "keywords": [
     "lynxtron",

--- a/src/packages/lynxtron/package.json
+++ b/src/packages/lynxtron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/lynxtron",
-  "version": "0.0.0-alpha",
+  "version": "0.0.18",
   "description": "lynxtron npm package test",
   "type": "module",
   "types": "./apis/lynxtron.d.ts",

--- a/src/packages/publish_prepare.py
+++ b/src/packages/publish_prepare.py
@@ -83,6 +83,12 @@ PREPARE_CONFIG = {
     "cef-webview": {
         "package_dir": "./cef-webview",
         "base_url_rewrite": True,
+        "replaces": {
+            "@lynx-js/lynxtron": {
+                "name": "@lynx-js/lynxtron",
+                "version": "",
+            },
+        },
     },
     "lynx-library-headers": {
         "package_dir": "./lynx-library-headers",

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -1031,6 +1031,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lynx-js/cef-webview@workspace:packages/cef-webview":
+  version: 0.0.0-use.local
+  resolution: "@lynx-js/cef-webview@workspace:packages/cef-webview"
+  dependencies:
+    "@lynx-js/lynxtron": "workspace:*"
+    cmake-js: "npm:^7.4.0"
+    js-yaml: "npm:^4.1.1"
+    node-addon-api: "npm:^7.0.0"
+    node-fetch: "npm:3.3.2"
+    plist: "npm:^3.1.0"
+    zip-lib: "npm:1.4.0"
+  languageName: unknown
+  linkType: soft
+
 "@lynx-js/chunk-loading-webpack-plugin@npm:^0.3.3":
   version: 0.3.4
   resolution: "@lynx-js/chunk-loading-webpack-plugin@npm:0.3.4"
@@ -1156,6 +1170,18 @@ __metadata:
     "@rsbuild/core": ^2.1.5
   bin:
     dev-ready-rspeedy: bin/cli-rspeedy.js
+  languageName: unknown
+  linkType: soft
+
+"@lynx-js/lynxtron-rebuild@workspace:packages/lynxtron-rebuild":
+  version: 0.0.0-use.local
+  resolution: "@lynx-js/lynxtron-rebuild@workspace:packages/lynxtron-rebuild"
+  dependencies:
+    compressing: "npm:^1.10.0"
+    node-fetch: "npm:^3.3.2"
+    node-gyp: "npm:^12.2.0"
+  bin:
+    lynxtron-rebuild: bin/lynxtron-rebuild.js
   languageName: unknown
   linkType: soft
 
@@ -4246,6 +4272,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aproba@npm:^1.0.3 || ^2.0.0":
+  version: 2.1.0
+  resolution: "aproba@npm:2.1.0"
+  checksum: ec8c1d351bac0717420c737eb062766fb63bde1552900e0f4fdad9eb064c3824fef23d1c416aa5f7a80f21ca682808e902d79b7c9ae756d342b5f1884f36932f
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "are-we-there-yet@npm:3.0.1"
+  dependencies:
+    delegates: "npm:^1.0.0"
+    readable-stream: "npm:^3.6.0"
+  checksum: 8373f289ba42e4b5ec713bb585acdac14b5702c75f2a458dc985b9e4fa5762bc5b46b40a21b72418a3ed0cfb5e35bdc317ef1ae132f3035f633d581dd03168c3
+  languageName: node
+  linkType: hard
+
 "argparse@npm:^1.0.7":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
@@ -4400,6 +4443,18 @@ __metadata:
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
   checksum: 9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.6.5":
+  version: 1.20.0
+  resolution: "axios@npm:1.20.0"
+  dependencies:
+    follow-redirects: "npm:^1.16.0"
+    form-data: "npm:^4.0.6"
+    https-proxy-agent: "npm:^5.0.1"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 976088acf532286356f4c2e65df1ef47ba7da3936d83e928d0d64357bbf5370456abd3eb5826c15df322335fcb1fe200d4a84b4fcf20ffccdd63b40d80fa495c
   languageName: node
   linkType: hard
 
@@ -4954,6 +5009,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chownr@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "chownr@npm:2.0.0"
+  checksum: 594754e1303672171cc04e50f6c398ae16128eb134a88f801bf5354fd96f205320f23536a045d9abd8b51024a149696e51231565891d4efdab8846021ecf88e6
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^3.0.0":
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
@@ -5067,6 +5129,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cmake-js@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "cmake-js@npm:7.4.0"
+  dependencies:
+    axios: "npm:^1.6.5"
+    debug: "npm:^4"
+    fs-extra: "npm:^11.2.0"
+    memory-stream: "npm:^1.0.0"
+    node-api-headers: "npm:^1.1.0"
+    npmlog: "npm:^6.0.2"
+    rc: "npm:^1.2.7"
+    semver: "npm:^7.5.4"
+    tar: "npm:^6.2.0"
+    url-join: "npm:^4.0.1"
+    which: "npm:^2.0.2"
+    yargs: "npm:^17.7.2"
+  bin:
+    cmake-js: bin/cmake-js
+  checksum: e0aa88fb9c181ec0a0a11dba6240c7778633528320f90cc13d2b1cbd50c20ef43d47684c0d2f49ad2fb8074b7c4792f32c2dfbc15f011b5548f17b1af84ade4d
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
@@ -5080,6 +5164,15 @@ __metadata:
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"color-support@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "color-support@npm:1.1.3"
+  bin:
+    color-support: bin.js
+  checksum: 8ffeaa270a784dc382f62d9be0a98581db43e11eee301af14734a6d089bd456478b1a8b3e7db7ca7dc5b18a75f828f775c44074020b51c05fc00e6d0992b1cc6
   languageName: node
   linkType: hard
 
@@ -5208,6 +5301,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     utils-merge: "npm:1.0.1"
   checksum: f120c6116bb16a0a7d2703c0b4a0cd7ed787dc5ec91978097bf62aa967289020a9f41a9cd3c3276a7b92aaa36f382d2cd35fed7138fd466a55c8e9fdbed11ca8
+  languageName: node
+  linkType: hard
+
+"console-control-strings@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "console-control-strings@npm:1.1.0"
+  checksum: 7ab51d30b52d461412cd467721bb82afe695da78fff8f29fe6f6b9cbaac9a2328e27a22a966014df9532100f6dd85370460be8130b9c677891ba36d96a343f50
   languageName: node
   linkType: hard
 
@@ -5714,7 +5814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:~4.4.1":
+"debug@npm:4, debug@npm:^4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:~4.4.1":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -5769,6 +5869,13 @@ __metadata:
   dependencies:
     type-detect: "npm:^4.0.0"
   checksum: 264e0613493b43552fc908f4ff87b8b445c0e6e075656649600e1b8a17a57ee03e960156fce7177646e4d2ddaf8e5ee616d76bd79929ff593e5c79e4e5e6c517
+  languageName: node
+  linkType: hard
+
+"deep-extend@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "deep-extend@npm:0.6.0"
+  checksum: 1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
   languageName: node
   linkType: hard
 
@@ -5828,6 +5935,13 @@ __metadata:
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
   checksum: d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
+  languageName: node
+  linkType: hard
+
+"delegates@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "delegates@npm:1.0.0"
+  checksum: ba05874b91148e1db4bf254750c042bf2215febd23a6d3cda2e64896aef79745fbd4b9996488bd3cafb39ce19dbce0fd6e3b6665275638befffe1c9b312b91b5
   languageName: node
   linkType: hard
 
@@ -6758,6 +6872,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
+  languageName: node
+  linkType: hard
+
 "formdata-polyfill@npm:^4.0.10":
   version: 4.0.10
   resolution: "formdata-polyfill@npm:4.0.10"
@@ -6807,6 +6934,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^11.2.0":
+  version: 11.4.0
+  resolution: "fs-extra@npm:11.4.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 1e311eca820a12d3d795f2043dcd5628d017f4d21e634f3f9ef314ae68bee9979758262fb9cb35ffa6f26454c3fffe8b15558733e91e8fc729b07b10bb98d8b6
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^7.0.1":
   version: 7.0.1
   resolution: "fs-extra@npm:7.0.1"
@@ -6838,6 +6976,15 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 9b808bd884beff5cb940773018179a6b94a966381d005479f00adda6b44e5e3d4abf765135773d849cc27efe68c349e4a7b86acd7d3306d5932c14f3a4b17a92
+  languageName: node
+  linkType: hard
+
+"fs-minipass@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "fs-minipass@npm:2.1.0"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 703d16522b8282d7299337539c3ed6edddd1afe82435e4f5b76e34a79cd74e488a8a0e26a636afc2440e1a23b03878e2122e3a2cfe375a5cf63c37d92b86a004
   languageName: node
   linkType: hard
 
@@ -6901,6 +7048,22 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: 33e77fd29bddc2d9bb78ab3eb854c165909201f88c75faa8272e35899e2d35a8a642a15e7420ef945e1f64a9670d6aa3ec744106b2aa42be68ca5114025954ca
+  languageName: node
+  linkType: hard
+
+"gauge@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "gauge@npm:4.0.4"
+  dependencies:
+    aproba: "npm:^1.0.3 || ^2.0.0"
+    color-support: "npm:^1.1.3"
+    console-control-strings: "npm:^1.1.0"
+    has-unicode: "npm:^2.0.1"
+    signal-exit: "npm:^3.0.7"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+    wide-align: "npm:^1.1.5"
+  checksum: ef10d7981113d69225135f994c9f8c4369d945e64a8fc721d655a3a38421b738c9fe899951721d1b47b73c41fdb5404ac87cc8903b2ecbed95d2800363e7e58c
   languageName: node
   linkType: hard
 
@@ -7172,12 +7335,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-unicode@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "has-unicode@npm:2.0.1"
+  checksum: ebdb2f4895c26bb08a8a100b62d362e49b2190bcfd84b76bc4be1a3bd4d254ec52d0dd9f2fbcc093fc5eb878b20c52146f9dfd33e2686ed28982187be593b47c
+  languageName: node
+  linkType: hard
+
 "hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -7401,6 +7580,13 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
+"ini@npm:~1.3.0":
+  version: 1.3.8
+  resolution: "ini@npm:1.3.8"
+  checksum: ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
   languageName: node
   linkType: hard
 
@@ -8449,6 +8635,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memory-stream@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "memory-stream@npm:1.0.0"
+  dependencies:
+    readable-stream: "npm:^3.4.0"
+  checksum: a2d9abd35845b228055ce5424dbdd8478711ba41325d02e6c8ef9baeba557287d4493a6e74d3db5c9849c58ea13fdc1dd445c96f469cbd02f47d22cfba930306
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -8480,7 +8675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.35, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -8683,6 +8878,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "minipass@npm:5.0.0"
+  checksum: a91d8043f691796a8ac88df039da19933ef0f633e3d7f0d35dcd5373af49131cf2399bfc355f41515dc495e3990369c3858cd319e5c2722b4753c90bf3152462
+  languageName: node
+  linkType: hard
+
 "minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0":
   version: 7.1.3
   resolution: "minipass@npm:7.1.3"
@@ -8694,6 +8896,16 @@ __metadata:
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
   checksum: b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
+  languageName: node
+  linkType: hard
+
+"minizlib@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "minizlib@npm:2.1.2"
+  dependencies:
+    minipass: "npm:^3.0.0"
+    yallist: "npm:^4.0.0"
+  checksum: 64fae024e1a7d0346a1102bb670085b17b7f95bf6cfdf5b128772ec8faf9ea211464ea4add406a3a6384a7d87a0cd1a96263692134323477b4fb43659a6cab78
   languageName: node
   linkType: hard
 
@@ -8714,6 +8926,15 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: e2e2be789218807b58abced04e7b49851d9e46e88a2f9539242cc8a92c9b5c3a0b9bab360bd3014e02a140fc4fbc58e31176c408b493f8a2a6f4986bd7527b01
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "mkdirp@npm:1.0.4"
+  bin:
+    mkdirp: bin/cmd.js
+  checksum: 46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
   languageName: node
   linkType: hard
 
@@ -8818,6 +9039,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-api-headers@npm:^1.1.0":
+  version: 1.9.0
+  resolution: "node-api-headers@npm:1.9.0"
+  checksum: 7702eb5218c25ff7cc96b4e342815b3bfe940cbd81f233015799e37dad4f34d34db68aa10945a5243b0c8d074f70fb88d90a553a088a52434c2343e532d50dc2
+  languageName: node
+  linkType: hard
+
 "node-api-version@npm:^0.2.1":
   version: 0.2.1
   resolution: "node-api-version@npm:0.2.1"
@@ -8834,7 +9062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:3.3.2":
+"node-fetch@npm:3.3.2, node-fetch@npm:^3.3.2":
   version: 3.3.2
   resolution: "node-fetch@npm:3.3.2"
   dependencies:
@@ -8862,6 +9090,26 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 31ff49586991b38287bb15c3d529dd689cfc32f992eed9e6997b9d712d5d21fe818a8b1bbfe3b76a7e33765c20210c5713212f4aa329306a615b87d8a786da3a
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:^12.2.0":
+  version: 12.4.0
+  resolution: "node-gyp@npm:12.4.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    graceful-fs: "npm:^4.2.6"
+    nopt: "npm:^9.0.0"
+    proc-log: "npm:^6.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^7.5.4"
+    tinyglobby: "npm:^0.2.12"
+    undici: "npm:^6.25.0"
+    which: "npm:^6.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 9acb7c798e124275a6f9c1f7eb64b5abd6196bb885a3945fb44ee0dccf435514e88cdfb0f228ee7ff76ef25107c1f39ff37a067bf92fd00b9aff9234db29ff9e
   languageName: node
   linkType: hard
 
@@ -8939,6 +9187,18 @@ __metadata:
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
   checksum: 95d948f9bdd2cfde91aa786d1816ae40f8262946e13700bf6628105994fe0ff361662c20af3961161c38a119dc977adeb41fc0b41b1745eb77edaaf9cb22db23
+  languageName: node
+  linkType: hard
+
+"npmlog@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "npmlog@npm:6.0.2"
+  dependencies:
+    are-we-there-yet: "npm:^3.0.0"
+    console-control-strings: "npm:^1.1.0"
+    gauge: "npm:^4.0.3"
+    set-blocking: "npm:^2.0.0"
+  checksum: 0cacedfbc2f6139c746d9cd4a85f62718435ad0ca4a2d6459cd331dd33ae58206e91a0742c1558634efcde3f33f8e8e7fd3adf1bfe7978310cf00bd55cccf890
   languageName: node
   linkType: hard
 
@@ -10250,6 +10510,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rc@npm:^1.2.7":
+  version: 1.2.8
+  resolution: "rc@npm:1.2.8"
+  dependencies:
+    deep-extend: "npm:^0.6.0"
+    ini: "npm:~1.3.0"
+    minimist: "npm:^1.2.0"
+    strip-json-comments: "npm:~2.0.1"
+  bin:
+    rc: ./cli.js
+  checksum: 24a07653150f0d9ac7168e52943cc3cb4b7a22c0e43c7dff3219977c2fdca5a2760a304a029c20811a0e79d351f57d46c9bde216193a0f73978496afc2b85b15
+  languageName: node
+  linkType: hard
+
 "read-binary-file-arch@npm:^1.0.6":
   version: 1.0.6
   resolution: "read-binary-file-arch@npm:1.0.6"
@@ -10288,7 +10562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.4.0":
+"readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -10909,7 +11183,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.7.2, semver@npm:^7.7.4":
+"semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.4":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -10940,6 +11214,13 @@ __metadata:
   version: 7.0.6
   resolution: "serialize-javascript@npm:7.0.6"
   checksum: 9d626d843c9177356520abf9bbf2c79b4aa2a0bcc4f7a4c8398e942aab1d22ecc567ad7f74de4a25d501b0126ee25b77f5b604147d5da1ff3bfa39544e35b423
+  languageName: node
+  linkType: hard
+
+"set-blocking@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "set-blocking@npm:2.0.0"
+  checksum: 9f8c1b2d800800d0b589de1477c753492de5c1548d4ade52f57f1d1f5e04af5481554d75ce5e5c43d4004b80a3eb714398d6907027dc0534177b7539119f4454
   languageName: node
   linkType: hard
 
@@ -11113,7 +11394,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2":
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
@@ -11373,7 +11654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -11482,6 +11763,13 @@ __metadata:
   dependencies:
     min-indent: "npm:^1.0.0"
   checksum: ae0deaf41c8d1001c5d4fbe16cb553865c1863da4fae036683b474fa926af9fc121e155cb3fc57a68262b2ae7d5b8420aa752c97a6428c315d00efe2a3875679
+  languageName: node
+  linkType: hard
+
+"strip-json-comments@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "strip-json-comments@npm:2.0.1"
+  checksum: b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
   languageName: node
   linkType: hard
 
@@ -11643,7 +11931,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.3, tar@npm:^7.5.6":
+"tar@npm:^6.2.0":
+  version: 6.2.1
+  resolution: "tar@npm:6.2.1"
+  dependencies:
+    chownr: "npm:^2.0.0"
+    fs-minipass: "npm:^2.0.0"
+    minipass: "npm:^5.0.0"
+    minizlib: "npm:^2.1.1"
+    mkdirp: "npm:^1.0.3"
+    yallist: "npm:^4.0.0"
+  checksum: a5eca3eb50bc11552d453488344e6507156b9193efd7635e98e867fab275d527af53d8866e2370cd09dfe74378a18111622ace35af6a608e5223a7d27fe99537
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.4.3, tar@npm:^7.5.4, tar@npm:^7.5.6":
   version: 7.5.22
   resolution: "tar@npm:7.5.22"
   dependencies:
@@ -12112,6 +12414,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^6.25.0":
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^4.0.0":
   version: 4.0.0
   resolution: "unique-filename@npm:4.0.0"
@@ -12216,6 +12525,13 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"url-join@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "url-join@npm:4.0.1"
+  checksum: ac65e2c7c562d7b49b68edddcf55385d3e922bc1dd5d90419ea40b53b6de1607d1e45ceb71efb9d60da02c681d13c6cb3a1aa8b13fc0c989dfc219df97ee992d
   languageName: node
   linkType: hard
 
@@ -12513,7 +12829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^2.0.1":
+"which@npm:^2.0.1, which@npm:^2.0.2":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:
@@ -12543,6 +12859,15 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: fe9d6463fe44a76232bb6e3b3181922c87510a5b250a98f1e43a69c99c079b3f42ddeca7e03d3e5f2241bf2d334f5a7657cfa868b97c109f3870625842f4cc15
+  languageName: node
+  linkType: hard
+
+"wide-align@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "wide-align@npm:1.1.5"
+  dependencies:
+    string-width: "npm:^1.0.2 || 2 || 3 || 4"
+  checksum: 1d9c2a3e36dfb09832f38e2e699c367ef190f96b82c71f809bc0822c306f5379df87bab47bed27ea99106d86447e50eb972d3c516c2f95782807a9d082fbea95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- add a manual alpha release path for any branch, tag, or commit
- resolve the selected source once and pin every build, GitHub Release, and npm publish job to that commit SHA
- add a Changesets workflow on `main` that creates or updates the Version Packages PR
- publish a stable release from the Version Packages merge commit through the same runtime pipeline
- keep the seven runtime-related npm packages in a Changesets fixed group and bootstrap their repository versions to the published `0.0.18` baseline
- add missing `cef-webview` and `lynxtron-rebuild` Yarn workspaces and prepare CEF workspace dependencies for npm publishing

## Release behavior

### Alpha

Run the `publish` workflow manually with, for example:

- `source_ref`: `feature/my-change`
- `tag`: `v0.0.19-alpha.0`

Manual releases are restricted to `alpha` versions.

### Stable

1. Merge package changesets into `main`.
2. The `changesets release` workflow creates or updates `chore: version packages`.
3. Merge that Version Packages PR.
4. The workflow publishes the stable runtime archives, GitHub Release, and npm packages from the exact merge commit.

An existing Git tag prevents duplicate stable publishing.

## Validation

- builder test suite: 30 tests passed
- `changeset status` succeeds and plans all seven packages at `0.0.19`
- simulated `changeset version` keeps all seven packages fixed at one version
- workflow YAML parse and actionlint checks pass
- immutable Yarn install passes
- CEF publish preparation rewrites its workspace dependency to the concrete release version
- `git diff --check`