### PR TITLE
chore: skip commit-message check for version packages commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Run commit-message check
         run: |
           cd ${{ github.workspace }}/lynxtron
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          if echo "$COMMIT_MSG" | grep -q "version packages"; then
+            echo "Skipping commit-message check for version packages commit"
+            exit 0
+          fi
           source lynxtron_tools/envsetup.sh
           python3 src/tools_shared/git_lynx.py check --checkers commit-message
       - name: Run coding-style check


### PR DESCRIPTION
When the latest commit message contains "chore: version packages", the commit-message check is skipped to avoid blocking automated version bump PRs.