### PR TITLE
[Infra] Fix CEF webview publish build by using yarn instead of npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -637,13 +637,11 @@ jobs:
           PLATFORM="darwin"
           ARCH="${{ matrix.arch }}"
           PACKAGE_DIR=${{ github.workspace }}/lynxtron/src/packages/cef-webview
+          # Install deps via yarn at the workspace root so that workspace:*
+          # protocol is resolved correctly (npm does not support it).
+          cd ${{ github.workspace }}/lynxtron/src
+          node tools/yarn.js install --immutable --mode=skip-build
           cd "$PACKAGE_DIR"
-          # Install only the build deps. The package's @lynx-js/lynxtron
-          # devDependency is not required for macOS native builds and is
-          # skipped to avoid resolving an unreleased version on the registry.
-          npm install --no-save --ignore-scripts \
-            cmake-js@^7.4.0 \
-            node-addon-api@^7.0.0
           if [ "$ARCH" = "arm64" ]; then
             export CMAKE_OSX_ARCHITECTURES=arm64
             npx cmake-js build

--- a/src/.changeset/fix-cef-publish-build.md
+++ b/src/.changeset/fix-cef-publish-build.md
@@ -1,0 +1,11 @@
+---
+"@lynx-js/cef-webview": patch
+"@lynx-js/lynxtron": patch
+"@lynx-js/lynxtron-builder": patch
+"@lynx-js/lynxtron-dev-plugins": patch
+"@lynx-js/lynxtron-rebuild": patch
+"@lynx-js/lynx-library-headers": patch
+"create-lynxtron": patch
+---
+
+Fix CEF webview publish build by using yarn instead of npm to resolve workspace:* protocol.


### PR DESCRIPTION
The cef-webview package.json uses workspace:* protocol for its @lynx-js/lynxtron devDependency, which npm does not support (EUNSUPPORTEDPROTOCOL). Switch to yarn install at the workspace root so workspace protocol is resolved correctly.