### PR TITLE
[BugFix] Update lynx's patch to fix skity render problem.

### DIFF
--- a/src/.changeset/fix-skity-render-issue.md
+++ b/src/.changeset/fix-skity-render-issue.md
@@ -1,0 +1,11 @@
+---
+"@lynx-js/lynxtron": patch
+"@lynx-js/lynxtron-builder": patch
+"@lynx-js/lynxtron-dev-plugins": patch
+"@lynx-js/lynxtron-rebuild": patch
+"@lynx-js/cef-webview": patch
+"@lynx-js/lynx-library-headers": patch
+"create-lynxtron": patch
+---
+
+Fix skity rendering issue with paints_into_platform_view_slice limited to Window

--- a/src/patches/lynx/0007-BugFix-Limit-paints_into_platform_view_slice-to-Wind.patch
+++ b/src/patches/lynx/0007-BugFix-Limit-paints_into_platform_view_slice-to-Wind.patch
@@ -1,21 +1,29 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From dc20f151aa13b2b01c03fd3bbf7312e9e74c5d53 Mon Sep 17 00:00:00 2001
 From: zsy-jason <186247581+zsy-jason@users.noreply.github.com>
-Date: Sat, 6 Sep 2026 00:00:00 +0000
+Date: Mon, 7 Sep 2026 15:49:17 +0800
 Subject: [PATCH] [BugFix] Limit paints_into_platform_view_slice to Windows
  Skity
 
+Set paints_into_platform_view_slice before ContainerLayer::Preroll when
+ENABLE_SKITY is defined.
 ---
+ clay/flow/layers/external_view_layer.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
 diff --git a/clay/flow/layers/external_view_layer.cc b/clay/flow/layers/external_view_layer.cc
-index 0da525e0b..d5eea8119 100644
+index 0da525e0..ef1d9e1c 100644
 --- a/clay/flow/layers/external_view_layer.cc
 +++ b/clay/flow/layers/external_view_layer.cc
-@@ -23,7 +23,9 @@ void ExternalViewLayer::Preroll(PrerollContext* context) {
+@@ -21,6 +21,9 @@ void ExternalViewLayer::Preroll(PrerollContext* context) {
+                        "does not support embedding";
+     return;
    }
++#ifdef ENABLE_SKITY
++  context->paints_into_platform_view_slice = true;
++#endif
    ContainerLayer::Preroll(context);
    context->has_platform_view = true;
-+#if defined(OS_WIN) && defined(ENABLE_SKITY)
    context->paints_into_platform_view_slice = true;
-+#endif
-   set_subtree_has_platform_view(true);
-   MutatorsStack mutators;
-   context->state_stack.fill(&mutators);
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
Windows Skity prerolls cover-view children in root-surface coordinates, but paints them into a DirectComposition overlay with a different Y-axis transform. RasterCache entries prepared before the subtree is marked as a platform-view slice can therefore render flipped or misplaced. Mark the subtree before child preroll so Layer and Picture RasterCache are skipped for this cross-surface path.