### PR TITLE
[BugFix][CEF] Support macOS cross-architecture builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -607,78 +607,13 @@ jobs:
         with:
           path: lynxtron
           ref: ${{ needs.get-version.outputs.source_sha }}
-      - name: Install Common Dependencies
-        uses: ./lynxtron/.github/actions/common-deps
-        with:
-          run-habitat-sync: 'false'
-      - name: Prepare environment
-        shell: bash
-        env:
-          HABITAT_CONCURRENCY: 2
-        run: |
-          set -euxo pipefail
-          cd ${{ github.workspace }}/lynxtron
-          git config --global http.version HTTP/1.1
-          git config --global user.name "Lynxtron Scripts"
-          git config --global user.email "scripts@lynxtron.com"
-          source lynxtron_tools/envsetup.sh
-          python3 lynxtron_tools/prepare_build_env.py
-          cd ${{ github.workspace }}/lynxtron/lynx/third_party/weak-node-api/
-          python3 setup_deps.py
-          # Sync CEF binary distribution required by cef-webview CMakeLists.
-          cd ${{ github.workspace }}/lynxtron/src
-          for attempt in 1 2 3; do
-            if "${{ github.workspace }}/lynxtron/lynxtron_tools/hab" sync . -f --no-history --target extension --target-only; then
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "sync CEF extension dependencies failed after 3 attempts"
-              exit 1
-            fi
-            delay=$((10 * (2 ** (attempt - 1))))
-            echo "sync CEF extension dependencies failed (attempt $attempt/3); retrying in $delay seconds..."
-            sleep "$delay"
-          done
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24.14.1
-      - name: Install CMake
-        shell: bash
-        run: |
-          brew install cmake
-          cmake --version
       - name: Build CEF webview
         shell: bash
         run: |
-          set -e
-          set -x
-          VERSION=${{ needs.get-version.outputs.version }}
-          PLATFORM="darwin"
-          ARCH="${{ matrix.arch }}"
-          PACKAGE_DIR=${{ github.workspace }}/lynxtron/src/packages/cef-webview
-          # Install deps via yarn at the workspace root so that workspace:*
-          # protocol is resolved correctly (npm does not support it).
-          cd ${{ github.workspace }}/lynxtron/src
-          node tools/yarn.js install --immutable --mode=skip-build
-          cd "$PACKAGE_DIR"
-          if [ "$ARCH" = "arm64" ]; then
-            export CMAKE_OSX_ARCHITECTURES=arm64
-            npx cmake-js build
-          else
-            export CMAKE_OSX_ARCHITECTURES=x86_64
-            arch -x86_64 npx cmake-js build
-          fi
-          ROOT_NAME="cef_webview-v${VERSION}-${PLATFORM}-${ARCH}"
-          TMP_DIR="$PACKAGE_DIR/_pack_tmp_${ARCH}"
-          rm -rf "$TMP_DIR"
-          mkdir -p "$TMP_DIR/$ROOT_NAME"
-          cp ./build/Release/cef_extension.node "$TMP_DIR/$ROOT_NAME/"
-          mkdir -p "$TMP_DIR/$ROOT_NAME/frameworks"
-          cp -R ./build/frameworks/Contents/Frameworks/* "$TMP_DIR/$ROOT_NAME/frameworks/"
-          mkdir -p ${{ github.workspace }}/lynxtron/publish
-          cd "$TMP_DIR"
-          zip -ry "${{ github.workspace }}/lynxtron/publish/${ROOT_NAME}.zip" "$ROOT_NAME"
-          ls -lh "${{ github.workspace }}/lynxtron/publish/${ROOT_NAME}.zip"
+          cd ${{ github.workspace }}/lynxtron
+          git config --global user.name "Lynxtron Scripts"
+          git config --global user.email "scripts@lynxtron.com"
+          python3 lynxtron_tools/build_cef_webview.py --arch "${{ matrix.arch }}" --version "${{ needs.get-version.outputs.version }}"
       - name: Upload CEF webview artifact
         uses: actions/upload-artifact@v4
         with:

--- a/lynxtron_tools/build_cef_webview.py
+++ b/lynxtron_tools/build_cef_webview.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Prepare, build and validate macOS CEF artifacts on either host architecture."""
+import argparse
+from pathlib import Path
+import platform
+import re
+import subprocess
+import tempfile
+
+from prepare_mac_cross_compile_env import prepare
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def run(*args, cwd=ROOT, env=None):
+    print('+', ' '.join(map(str, args)), flush=True)
+    subprocess.run(list(map(str, args)), cwd=cwd, env=env, check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--arch', choices=['arm64', 'x64'], required=True)
+    parser.add_argument('--version', help='Also create a release zip in publish/')
+    args = parser.parse_args()
+    if args.version and not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?', args.version):
+        parser.error('--version must be a release version, not a path')
+    if platform.system() != 'Darwin':
+        parser.error('This entry point requires macOS and Xcode Command Line Tools')
+    env = prepare(args.arch)
+    sdk = ROOT / 'third_party/cef_binary'
+    target = 'x86_64' if args.arch == 'x64' else 'arm64'
+    run('lipo', sdk / 'Release/Chromium Embedded Framework.framework/Chromium Embedded Framework', '-verify_arch', target)
+    src = ROOT / 'src'
+    run('node', 'tools/yarn.js', 'workspace', '@lynx-js/cef-webview', 'build', cwd=src, env=env)
+    output = src / 'packages/cef-webview/dist/darwin' / args.arch
+    binaries = [output / 'cef_extension.node']
+    binaries += list(output.glob('frameworks/*.app/Contents/MacOS/*'))
+    binaries += list(output.glob('frameworks/*.framework/Chromium Embedded Framework'))
+    if len(binaries) < 3:
+        raise RuntimeError('Missing framework or helper app in staged output')
+    for binary in binaries:
+        run('lipo', binary, '-verify_arch', target)
+        run('file', binary)
+    if args.version:
+        import shutil
+        deps = Path(tempfile.mkdtemp(prefix='lynxtron-cef-release-'))
+        name = f'cef_webview-v{args.version}-darwin-{args.arch}'
+        staging = deps / name
+        shutil.copytree(output, staging, symlinks=True)
+        publish = ROOT / 'publish'
+        publish.mkdir(exist_ok=True)
+        # Create a fresh archive so a repeated version cannot retain stale files.
+        run('zip', '-qry', deps / f'{name}.zip', name, cwd=deps)
+        shutil.move(str(deps / f'{name}.zip'), publish / f'{name}.zip')
+    print(f'Validated {args.arch} artifacts: {output}', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/lynxtron_tools/prepare_mac_cross_compile_env.py
+++ b/lynxtron_tools/prepare_mac_cross_compile_env.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Prepare macOS host tools and target dependencies using the shared setup."""
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def target_environment(arch):
+    if arch not in ('arm64', 'x64'):
+        raise ValueError(f'Unsupported macOS target: {arch}')
+    env = dict(os.environ)
+    env.update(npm_config_arch=arch, npm_config_platform='darwin',
+               LYNXTRON_SKIP_DOWNLOAD='1')
+    # Habitat selects Node for the host. Only DEPS.extension consumes the
+    # requested architecture when selecting the CEF SDK.
+    tool_paths = [ROOT / '.venv/bin', ROOT / 'buildtools/node/bin',
+                  ROOT / 'buildtools/cmake/CMake.app/Contents/bin']
+    env['PATH'] = os.pathsep.join(map(str, tool_paths)) + os.pathsep + env['PATH']
+    return env
+
+
+def prepare_python_environment(env):
+    subprocess.run([sys.executable, str(ROOT / 'lynxtron_tools/vpython_tools/vpython_env_setup.py'),
+                    '--root_dir', str(ROOT)], cwd=ROOT, env=env, check=True)
+    env['VIRTUAL_ENV'] = str(ROOT / '.venv')
+    env.pop('PYTHONHOME', None)
+    return str(ROOT / '.venv/bin/python3')
+
+
+def prepare(arch):
+    if platform.system() != 'Darwin':
+        raise RuntimeError('macOS and Xcode Command Line Tools are required')
+    env = target_environment(arch)
+    subprocess.run(['xcrun', '--find', 'clang++'], env=env, check=True)
+    python = prepare_python_environment(env)
+    subprocess.run([python, str(ROOT / 'lynxtron_tools/prepare_build_env.py')],
+                   cwd=ROOT, env=env, check=True)
+    subprocess.run([str(ROOT / 'lynxtron_tools/hab'), 'sync', '.',
+                    '--no-history', '--target', 'extension', '--target-only'],
+                   cwd=ROOT / 'src', env=env, check=True)
+    subprocess.run([python, 'setup_deps.py'],
+                   cwd=ROOT / 'lynx/third_party/weak-node-api', env=env, check=True)
+    subprocess.run(['node', '--version'], env=env, check=True)
+    subprocess.run(['cmake', '--version'], env=env, check=True)
+    return env

--- a/lynxtron_tools/test_prepare_mac_cross_compile_env.py
+++ b/lynxtron_tools/test_prepare_mac_cross_compile_env.py
@@ -1,0 +1,68 @@
+# Copyright 2026 The Lynxtron Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import runpy
+import unittest
+from unittest import mock
+
+from lynxtron_tools import prepare_mac_cross_compile_env as setup
+
+
+class MacCrossCompileTest(unittest.TestCase):
+    def test_target_does_not_change_host_tools(self):
+        with mock.patch.dict(os.environ, {'PATH': '/usr/bin'}, clear=True):
+            arm = setup.target_environment('arm64')
+            intel = setup.target_environment('x64')
+        self.assertEqual(arm['PATH'], intel['PATH'])
+        self.assertEqual(intel['npm_config_arch'], 'x64')
+        self.assertEqual(intel['npm_config_platform'], 'darwin')
+        self.assertEqual(intel['LYNXTRON_SKIP_DOWNLOAD'], '1')
+        self.assertEqual(intel['PATH'].split(os.pathsep)[0], str(setup.ROOT / '.venv/bin'))
+
+    def test_preparation_uses_shared_setup_then_habitat(self):
+        with mock.patch.object(setup.platform, 'system', return_value='Darwin'), \
+                mock.patch.object(setup.subprocess, 'run') as run:
+            env = setup.prepare('x64')
+        calls = run.call_args_list
+        python = str(setup.ROOT / '.venv/bin/python3')
+        self.assertIn('vpython_env_setup.py', calls[1].args[0][1])
+        self.assertEqual(calls[1].args[0][2:], ['--root_dir', str(setup.ROOT)])
+        self.assertEqual(calls[2].args[0], [python, str(setup.ROOT / 'lynxtron_tools/prepare_build_env.py')])
+        self.assertEqual(calls[3].args[0][1:],
+                         ['sync', '.', '--no-history', '--target', 'extension', '--target-only'])
+        self.assertEqual(calls[4].args[0], [python, 'setup_deps.py'])
+        self.assertEqual(calls[4].kwargs['cwd'], setup.ROOT / 'lynx/third_party/weak-node-api')
+        self.assertEqual(env['VIRTUAL_ENV'], str(setup.ROOT / '.venv'))
+        for call in calls:
+            self.assertEqual(call.kwargs['env'], env)
+            self.assertTrue(call.kwargs['check'])
+
+    def test_python_setup_failure_stops_before_habitat(self):
+        failure = setup.subprocess.CalledProcessError(1, 'vpython_env_setup.py')
+        with mock.patch.object(setup.platform, 'system', return_value='Darwin'), \
+                mock.patch.object(setup.subprocess, 'run', side_effect=[None, failure]) as run:
+            with self.assertRaises(setup.subprocess.CalledProcessError):
+                setup.prepare('arm64')
+        self.assertEqual(run.call_count, 2)
+
+    def test_dependency_selection_separates_host_and_target(self):
+        for target, suffix in [('x64', 'macosx64'), ('arm64', 'macosarm64')]:
+            with mock.patch.dict(os.environ, {'npm_config_arch': target}), \
+                    mock.patch('platform.system', return_value='Darwin'), \
+                    mock.patch('platform.machine', return_value='arm64'):
+                deps = runpy.run_path(str(setup.ROOT / 'src/dependencies/DEPS.extension'))['deps']
+                tools = runpy.run_path(str(setup.ROOT / 'src/dependencies/DEPS.tools_shared'),
+                                      init_globals={'root_dir': str(setup.ROOT / 'src')})['deps']
+            self.assertIn(suffix, deps['../third_party/cef_binary']['url'])
+            self.assertIn('macos-universal', deps['../buildtools/cmake']['url'])
+            self.assertIn('darwin-arm64', tools['../buildtools/node']['url'])
+
+    def test_unsupported_target_fails_before_setup(self):
+        with self.assertRaises(ValueError):
+            setup.target_environment('x86')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lynxtron_tools/vpython_tools/vpython_env_setup.py
+++ b/lynxtron_tools/vpython_tools/vpython_env_setup.py
@@ -77,7 +77,7 @@ def main():
   python_bin_path = os.path.join(args.root_dir, ".venv", "bin") if system != "Windows" else os.path.join(args.root_dir, ".venv", "Scripts")
   if create_venv(python_bin_path, args.root_dir):
       return install_requirements(python_bin_path, args.python_package_index, args.root_dir, args.pip_install_args)
-  return 0
+  return 1
 
 if __name__ == "__main__":
-  main()
+  sys.exit(main())

--- a/src/.changeset/cef-macos-cross-build.md
+++ b/src/.changeset/cef-macos-cross-build.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/cef-webview": patch
+---
+
+Build macOS CEF artifacts for an explicit target architecture using host-native
+tools, Habitat-managed CMake and CEF SDKs, and the same entry point locally and
+in the release workflow. Verify native artifact architectures before packaging.

--- a/src/dependencies/DEPS.extension
+++ b/src/dependencies/DEPS.extension
@@ -1,11 +1,20 @@
 import os
 import platform
 
-machine = platform.machine().lower()
+machine = os.environ.get('npm_config_arch', platform.machine()).lower()
+machine = "x86_64" if machine == "x64" else machine
 machine = "x86_64" if machine == "amd64" else machine
 system = platform.system().lower()
 
 deps = {
+    # CMake runs on the host; the macOS distribution contains both CPU slices.
+    '../buildtools/cmake': {
+        'type': 'http',
+        'url': 'https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-macos-universal.tar.gz',
+        'sha256': '330b9514f5112e5ed4fb08b8b05803b776fd9b539a6ae12927d14dcc0ee2ba8d',
+        'ignore_in_git': True,
+        'condition': system == 'darwin',
+    },
     '../third_party/cef_binary': {
         "type": "http",
         "url": {

--- a/src/packages/cef-webview/CMakeLists.txt
+++ b/src/packages/cef-webview/CMakeLists.txt
@@ -39,6 +39,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CEF_ROOT}/cmake")
 # Load the CEF configuration.
 #
 # Execute FindCEF.cmake which must exist in CMAKE_MODULE_PATH.
+if(NODE_ARCH STREQUAL "x64")
+  set(PROJECT_ARCH "x86_64")
+elseif(NODE_ARCH STREQUAL "arm64")
+  set(PROJECT_ARCH "arm64")
+elseif(NODE_ARCH STREQUAL "ia32")
+  set(PROJECT_ARCH "x86")
+endif()
 find_package(CEF REQUIRED)
 
 #

--- a/src/packages/cef-webview/README.md
+++ b/src/packages/cef-webview/README.md
@@ -64,6 +64,19 @@ explicitly to the package build. Use `-ImportLibrary <path>` for another
 source-build output. A missing import library fails before compilation instead
 of falling back to a downloaded runtime.
 
+### macOS cross-compilation
+
+From the repository root, use the same entry point as the release workflow:
+
+```bash
+python3 lynxtron_tools/build_cef_webview.py --arch x64
+```
+
+The script prepares host tools and the target CEF SDK, builds the package and
+checks the addon, Framework and helper architectures. Use `--arch arm64` for
+Apple Silicon or add `--version <version>` to produce a release zip in
+`publish/`. No Rosetta Node process or manual Homebrew installation is required.
+
 ## Dependencies
 
 - **Runtime Dependencies:**

--- a/src/packages/cef-webview/test/build.test.js
+++ b/src/packages/cef-webview/test/build.test.js
@@ -11,6 +11,22 @@ const source = fs
   .replace(/^import .*;\n/gm, '')
   .replace('const require = createRequire(import.meta.url);', '');
 
+test('CEF receives the Node target before choosing compiler architectures', () => {
+  const cmake = fs.readFileSync(
+    new URL('../CMakeLists.txt', import.meta.url),
+    'utf8'
+  );
+  const setup = cmake.slice(0, cmake.indexOf('find_package(CEF REQUIRED)'));
+  assert.match(
+    setup,
+    /if\(NODE_ARCH STREQUAL "x64"\)\s+set\(PROJECT_ARCH "x86_64"\)/
+  );
+  assert.match(
+    setup,
+    /elseif\(NODE_ARCH STREQUAL "arm64"\)\s+set\(PROJECT_ARCH "arm64"\)/
+  );
+});
+
 for (const arch of ['x64', 'arm64']) {
   test(`arm64 Node passes explicit ${arch} target to cmake-js`, () => {
     let invocation;

--- a/src/packages/lynxtron-builder/test/publish-workflow.test.js
+++ b/src/packages/lynxtron-builder/test/publish-workflow.test.js
@@ -268,21 +268,24 @@ test('macOS releases publish both universal slice architectures', () => {
   );
 });
 
-test('macOS publish jobs preserve sibling architectures and cache CEF dependencies', () => {
+test('macOS CEF publishes use the same target-aware build entry as local builds', () => {
   assert.equal(jobs['build-macos'].strategy['fail-fast'], false);
   assert.equal(jobs['build-cef-webview-macos'].strategy['fail-fast'], false);
 
   const cefJob = jobs['build-cef-webview-macos'];
-  const cacheStep = cefJob.steps.find(
-    (step) => step.uses === './lynxtron/.github/actions/common-deps'
+  const build = cefJob.steps.find((step) => step.name === 'Build CEF webview');
+  for (const field of ['name', 'email']) {
+    const config = build.run.indexOf(`git config --global user.${field}`);
+    assert.ok(config >= 0 && config < build.run.indexOf('python3 lynxtron_tools/'));
+  }
+  assert.match(
+    build.run,
+    /python3 lynxtron_tools\/build_cef_webview.py --arch/
   );
-  assert.ok(cacheStep, 'CEF builds must restore and save the Habitat cache');
-  assert.equal(cacheStep.with['run-habitat-sync'], 'false');
-
-  const prepareStep = cefJob.steps.find((step) => step.name === 'Prepare environment');
-  assert.equal(prepareStep.env.HABITAT_CONCURRENCY, 2);
-  assert.match(prepareStep.run, /for attempt in 1 2 3/);
-  assert.match(prepareStep.run, /10 \* \(2 \*\* \(attempt - 1\)\)/);
+  assert.ok(build.run.includes('${{ matrix.arch }}'));
+  assert.ok(build.run.includes('${{ needs.get-version.outputs.version }}'));
+  assert.equal(cefJob.steps.filter((step) => step.run).length, 1);
+  assert.doesNotMatch(build.run, /arch -x86_64|brew install|cmake-js/);
 });
 
 test('pull request CI builds every published architecture', () => {


### PR DESCRIPTION
## Dependency and scope
Depends on #252. The base branch codex/cef-build-artifacts-base is an exact snapshot of #252 at f2b51c69ec075d30690bddef7b4ab0b0297767a5, so this review shows only the macOS cross-compilation delta (one commit).
Do not merge into the temporary base branch. Once #252 is merged, rebase and retarget this PR to main.

Extracted from #234. AutoLink and browser-demo changes stay in #234; no existing alpha tag or PR source branch was modified.

## Changes
- Separate host tool architecture from the requested CEF target architecture.
- Select the CEF SDK for the target and obtain universal macOS CMake through Habitat.
- Add a macOS preparation script using the existing shared setup and weak-node-api dependency setup.
- Build through the package command, verify addon/framework/helper CPU architectures, and optionally create a release archive preserving symlinks.
- Make the release workflow call the same entry point as local builds, removing inline setup, brew installation and Rosetta Node invocation.

Local/release entry point:
python3 lynxtron_tools/build_cef_webview.py --arch x64 [--version VERSION]

## Validation
- 4 Python preparation/dependency-selection tests passed.
- 13 CEF/install-policy tests passed (includes inherited prerequisite tests).
- 14 publish-workflow tests passed.
- git diff --check passed.
- No package manifests or lockfile changed relative to #252.
- This extraction has not rerun a full native macOS x64 build; unit and fixture results do not establish native build success. Complete native verification remains pending.