### PR TITLE
[BugFix][AutoLink] Integrate native libraries in development builds

### DIFF
--- a/src/.changeset/autolink-dev-integration.md
+++ b/src/.changeset/autolink-dev-integration.md
@@ -1,0 +1,8 @@
+---
+"@lynx-js/cef-webview": patch
+"@lynx-js/lynxtron-dev-plugins": patch
+---
+
+Register and load the CEF webview through AutoLink. Select literal target-specific
+runtime artifacts from lynx.lib.json, stage them after emit, and resolve generated
+loaders from the application output without copying entire dependency packages.

--- a/src/packages/cef-webview/CMakeLists.txt
+++ b/src/packages/cef-webview/CMakeLists.txt
@@ -96,6 +96,7 @@ add_subdirectory(${CEF_PLUGIN_SRC_DIR} cef_webview)
 set(CEF_EXTENSION_TARGET "cef_extension")
 set(CEF_EXTENSION_SRCS
   bindings/bind_napi.cc
+  bindings/register_webview.cc
   )
 
 add_library(${CEF_EXTENSION_TARGET} SHARED ${CEF_EXTENSION_SRCS})
@@ -106,6 +107,7 @@ if(MSVC)
   target_compile_options(${CEF_EXTENSION_TARGET} PRIVATE /FS)
 endif()
 target_include_directories(${CEF_EXTENSION_TARGET} PRIVATE
+  ${LYNX_LIBRARY_HEADERS_DIR}/include
   ${CMAKE_JS_INC}
   ${NODE_ADDON_API_DIR}
   ${PROJECT_ROOT_DIR}

--- a/src/packages/cef-webview/README.md
+++ b/src/packages/cef-webview/README.md
@@ -19,6 +19,11 @@ Enable the Lynxtron autolink plugin in your application build. AutoLink requires
 addon so its static Lynx registrations run during startup. CEF itself is
 initialized only when you call `initialize()`.
 
+The package registers `<webview>` through the native AutoLink registration API
+and selects its addon from the literal target paths in `lynx.lib.json`.
+The manifest also declares the CEF Framework/helper bundles on macOS and the
+DLLs, subprocess and resource files on Windows for development staging.
+
 ```ts
 import cefWebview from '@lynx-js/cef-webview/lynxtron';
 

--- a/src/packages/cef-webview/bindings/register_webview.cc
+++ b/src/packages/cef-webview/bindings/register_webview.cc
@@ -1,0 +1,13 @@
+// Copyright 2025 The Lynxtron Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <lynx/registration.h>
+
+extern "C" lynx_native_view_t* cef_webview_create_view(void* opaque);
+
+LYNX_REGISTER_ELEMENT("CEFWebviewElementModule",
+                      "webview",
+                      cef_webview_create_view,
+                      false,
+                      nullptr)

--- a/src/packages/cef-webview/index.cjs
+++ b/src/packages/cef-webview/index.cjs
@@ -1,20 +1,42 @@
-
 const path = require('path');
-const platform = process.platform;
-const arch = process.arch;
+const manifest = require('./lynx.lib.json');
 
-if (platform === 'win32') {
-  const runtimeDirectory = path.join(__dirname, 'dist', platform, arch);
-  process.env.PATH = `${runtimeDirectory};${process.env.PATH || ''}`;
+const target = manifest.platforms.lynxtron.targets.find(
+  ({ os, arch }) => os === process.platform && arch === process.arch
+);
+
+if (!target) {
+  throw new Error(
+    `@lynx-js/cef-webview does not provide a binary for ${process.platform}/${process.arch}`
+  );
 }
 
-const nativeBinding = require(path.join(
-  __dirname,
-  'dist',
-  platform,
-  arch,
-  'cef_extension.node',
-));
+const binaryPaths = Array.isArray(target.files)
+  ? target.files.filter((file) => path.extname(file) === '.node')
+  : [];
+if (binaryPaths.length === 0) {
+  throw new Error(
+    `@lynx-js/cef-webview does not provide a binary for ${process.platform}/${process.arch}`
+  );
+}
+if (process.platform === 'win32') {
+  const runtimeDirectory = path.dirname(
+    path.resolve(__dirname, binaryPaths[0])
+  );
+  process.env.PATH = `${runtimeDirectory};${process.env.PATH || ''}`;
+}
+const nativeBindings = binaryPaths.map((binaryPath) =>
+  require(path.resolve(__dirname, binaryPath))
+);
+const nativeBinding = nativeBindings.find(
+  (binding) => typeof binding.initialize === 'function'
+);
+
+if (!nativeBinding) {
+  throw new Error(
+    `@lynx-js/cef-webview did not load an initialize-capable binary for ${process.platform}/${process.arch}`
+  );
+}
 
 function initialize(options = {}) {
   return nativeBinding.initialize(options);

--- a/src/packages/cef-webview/lynx.lib.json
+++ b/src/packages/cef-webview/lynx.lib.json
@@ -1,7 +1,62 @@
 {
   "platforms": {
     "lynxtron": {
-      "path": "dist"
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "files": ["dist/darwin/arm64/cef_extension.node"],
+          "frameworks": [
+            "dist/darwin/arm64/frameworks/Chromium Embedded Framework.framework"
+          ],
+          "appBundles": [
+            "dist/darwin/arm64/frameworks/LynxtronWebview Helper.app",
+            "dist/darwin/arm64/frameworks/LynxtronWebview Helper (Alerts).app",
+            "dist/darwin/arm64/frameworks/LynxtronWebview Helper (GPU).app",
+            "dist/darwin/arm64/frameworks/LynxtronWebview Helper (Plugin).app",
+            "dist/darwin/arm64/frameworks/LynxtronWebview Helper (Renderer).app"
+          ]
+        },
+        {
+          "os": "darwin",
+          "arch": "x64",
+          "files": ["dist/darwin/x64/cef_extension.node"],
+          "frameworks": [
+            "dist/darwin/x64/frameworks/Chromium Embedded Framework.framework"
+          ],
+          "appBundles": [
+            "dist/darwin/x64/frameworks/LynxtronWebview Helper.app",
+            "dist/darwin/x64/frameworks/LynxtronWebview Helper (Alerts).app",
+            "dist/darwin/x64/frameworks/LynxtronWebview Helper (GPU).app",
+            "dist/darwin/x64/frameworks/LynxtronWebview Helper (Plugin).app",
+            "dist/darwin/x64/frameworks/LynxtronWebview Helper (Renderer).app"
+          ]
+        },
+        {
+          "os": "win32",
+          "arch": "x64",
+          "files": [
+            "dist/win32/x64/cef_extension.node",
+            "dist/win32/x64/cef_subprocess.exe",
+            "dist/win32/x64/chrome_100_percent.pak",
+            "dist/win32/x64/chrome_200_percent.pak",
+            "dist/win32/x64/chrome_elf.dll",
+            "dist/win32/x64/d3dcompiler_47.dll",
+            "dist/win32/x64/dxcompiler.dll",
+            "dist/win32/x64/dxil.dll",
+            "dist/win32/x64/icudtl.dat",
+            "dist/win32/x64/libcef.dll",
+            "dist/win32/x64/libEGL.dll",
+            "dist/win32/x64/libGLESv2.dll",
+            "dist/win32/x64/locales",
+            "dist/win32/x64/resources.pak",
+            "dist/win32/x64/v8_context_snapshot.bin",
+            "dist/win32/x64/vk_swiftshader_icd.json",
+            "dist/win32/x64/vk_swiftshader.dll",
+            "dist/win32/x64/vulkan-1.dll"
+          ]
+        }
+      ]
     }
   }
 }

--- a/src/packages/cef-webview/test/index.test.js
+++ b/src/packages/cef-webview/test/index.test.js
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const entrySource = fs.readFileSync(
+  path.resolve(__dirname, '../index.cjs'),
+  'utf8'
+);
+const cmakeSource = fs.readFileSync(
+  path.resolve(__dirname, '../CMakeLists.txt'),
+  'utf8'
+);
+const manifest = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../lynx.lib.json'), 'utf8')
+);
+
+function loadEntry({ platform, arch, manifest }) {
+  const module = { exports: {} };
+  const loadedPaths = [];
+  const context = {
+    __dirname: platform === 'win32' ? 'C:\\cef-webview' : '/cef-webview',
+    module,
+    exports: module.exports,
+    process: { platform, arch, env: { PATH: 'C:\\Windows\\System32' } },
+    require(specifier) {
+      if (specifier === 'path') {
+        return platform === 'win32' ? path.win32 : path.posix;
+      }
+      if (specifier === './lynx.lib.json') {
+        return manifest;
+      }
+      loadedPaths.push(specifier);
+      return {
+        initialize(options) {
+          return { options, platform, arch };
+        },
+      };
+    },
+  };
+
+  vm.runInNewContext(entrySource, context, { filename: 'index.cjs' });
+  return { entry: module.exports, loadedPaths, process: context.process };
+}
+
+test('loads the Windows x64 binary selected by lynx.lib.json', () => {
+  const { entry, loadedPaths, process } = loadEntry({
+    platform: 'win32',
+    arch: 'x64',
+    manifest: {
+      platforms: {
+        lynxtron: {
+          targets: [
+            {
+              os: 'darwin',
+              arch: 'arm64',
+              files: ['dist/darwin/arm64/cef_extension.node'],
+            },
+            {
+              os: 'win32',
+              arch: 'x64',
+              files: [
+                'dist/win32/x64/cef_extension.node',
+                'dist/win32/x64/libcef.dll',
+              ],
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(loadedPaths, [
+    'C:\\cef-webview\\dist\\win32\\x64\\cef_extension.node',
+  ]);
+  assert.equal(
+    process.env.PATH,
+    'C:\\cef-webview\\dist\\win32\\x64;C:\\Windows\\System32'
+  );
+  assert.deepEqual(entry.initialize({ cachePath: 'cache' }), {
+    options: { cachePath: 'cache' },
+    platform: 'win32',
+    arch: 'x64',
+  });
+});
+
+test('fails clearly when the installed package has no matching binary', () => {
+  assert.throws(
+    () =>
+      loadEntry({
+        platform: 'win32',
+        arch: 'x64',
+        manifest: {
+          platforms: {
+            lynxtron: {
+              targets: [
+                {
+                  os: 'darwin',
+                  arch: 'arm64',
+                  files: ['dist/darwin/arm64/cef_extension.node'],
+                },
+              ],
+            },
+          },
+        },
+      }),
+    /does not provide a binary for win32\/x64/
+  );
+});
+
+test('macOS metadata publishes the package-owned CEF bundles', () => {
+  const target = manifest.platforms.lynxtron.targets.find(
+    ({ os, arch }) => os === 'darwin' && arch === 'arm64'
+  );
+
+  assert.deepEqual(target.frameworks, [
+    'dist/darwin/arm64/frameworks/Chromium Embedded Framework.framework',
+  ]);
+  assert.deepEqual(target.appBundles, [
+    'dist/darwin/arm64/frameworks/LynxtronWebview Helper.app',
+    'dist/darwin/arm64/frameworks/LynxtronWebview Helper (Alerts).app',
+    'dist/darwin/arm64/frameworks/LynxtronWebview Helper (GPU).app',
+    'dist/darwin/arm64/frameworks/LynxtronWebview Helper (Plugin).app',
+    'dist/darwin/arm64/frameworks/LynxtronWebview Helper (Renderer).app',
+  ]);
+  assert.match(
+    cmakeSource,
+    /set\(CEF_WEBVIEW_HELPER_NAME "LynxtronWebview"\)/
+  );
+  assert.match(
+    cmakeSource,
+    /set\(CEF_WEBVIEW_HELPER_BUNDLE_ID "org\.lynxjs\.lynxtron\.webview\.helper"\)/
+  );
+});
+
+test('Windows metadata declares the CEF runtime payload', () => {
+  assert.deepEqual(
+    manifest.platforms.lynxtron.targets.find(
+      ({ os, arch }) => os === 'win32' && arch === 'x64'
+    ).files,
+    [
+      'dist/win32/x64/cef_extension.node',
+      'dist/win32/x64/cef_subprocess.exe',
+      'dist/win32/x64/chrome_100_percent.pak',
+      'dist/win32/x64/chrome_200_percent.pak',
+      'dist/win32/x64/chrome_elf.dll',
+      'dist/win32/x64/d3dcompiler_47.dll',
+      'dist/win32/x64/dxcompiler.dll',
+      'dist/win32/x64/dxil.dll',
+      'dist/win32/x64/icudtl.dat',
+      'dist/win32/x64/libcef.dll',
+      'dist/win32/x64/libEGL.dll',
+      'dist/win32/x64/libGLESv2.dll',
+      'dist/win32/x64/locales',
+      'dist/win32/x64/resources.pak',
+      'dist/win32/x64/v8_context_snapshot.bin',
+      'dist/win32/x64/vk_swiftshader_icd.json',
+      'dist/win32/x64/vk_swiftshader.dll',
+      'dist/win32/x64/vulkan-1.dll',
+    ]
+  );
+});

--- a/src/packages/lynxtron-dev-plugins/README.md
+++ b/src/packages/lynxtron-dev-plugins/README.md
@@ -91,8 +91,19 @@ Rsbuild. It includes Lynxtron AutoLink by default, so dependencies with
 `lynx.lib.json` and a `lynxtron` platform record are staged and loaded
 automatically.
 
-For `lynxtron`, `lynx.lib.json` describes the native asset root, such as
-`dist`, while the package's `./lynxtron` export provides the JS entry.
+For `lynxtron`, the package's `./lynxtron` export provides the JS registration
+entry. Its `lynx.lib.json` uses a `targets` array. Every target declares `os`,
+`arch`, and at least one string array named `files`, `frameworks`, or
+`appBundles`. AutoLink selects one matching target and stages only its declared
+artifacts together with the package metadata and `./lynxtron` entry. The opaque
+top-level `path` and artifact fields outside a target are not supported by this
+prerelease schema.
+
+Library producers must publish literal package-relative artifact paths in every
+target; variables and globs are not supported. Use standard `os` values
+(`darwin`, `win32`, `linux`) and `arch` values (`arm64`, `x64`, `ia32`), not
+aliases such as `macos` or `x86_64`. AutoLink selects the build target without
+expanding paths or rewriting the staged `lynx.lib.json`.
 
 ```ts
 import { pluginLynxtron } from '@lynx-js/lynxtron-dev-plugins/rspack';

--- a/src/packages/lynxtron-dev-plugins/index.js
+++ b/src/packages/lynxtron-dev-plugins/index.js
@@ -29,7 +29,10 @@ const restartLynxtron = debounce((options) => {
     } catch {}
 
     const { entry, args = [], env = {}, command = 'lynxtron' } = options;
-    const spawnArgs = [...args, entry];
+    // The Lynxtron runtime treats argv[1] as the application directory.
+    // Keep it first so runtime flags cannot be mistaken for the app path by
+    // the runtime or generated AutoLink loaders.
+    const spawnArgs = [entry, ...args];
 
     lynxtronProcess = spawn(command, spawnArgs, {
       stdio: 'inherit',

--- a/src/packages/lynxtron-dev-plugins/src/autolink-rspack.ts
+++ b/src/packages/lynxtron-dev-plugins/src/autolink-rspack.ts
@@ -47,8 +47,9 @@ export function applyLynxtronAutoLink(
 
   compiler.hooks?.beforeRun?.tap('LynxtronAutoLink', regenerate);
   compiler.hooks?.watchRun?.tap('LynxtronAutoLink', regenerate);
-  compiler.hooks?.beforeRun?.tap('LynxtronAutoLinkStage', stage);
-  compiler.hooks?.watchRun?.tap('LynxtronAutoLinkStage', stage);
+  // Rsbuild cleans the output directory after beforeRun. Stage native files
+  // after Rspack emits assets so the cleanup cannot remove them.
+  compiler.hooks?.afterEmit?.tap('LynxtronAutoLinkStage', stage);
 }
 
 function shouldInjectForTarget(target: unknown, force = false): boolean {
@@ -102,9 +103,7 @@ function ensureAutoLinkModule(
     options.nativeOutputDir
   );
 
-  writeLynxtronAutoLinkModule(resolution, generatedModule, {
-    stagedLibraries,
-  });
+  writeLynxtronAutoLinkModule(generatedModule, stagedLibraries);
   const aliases = writeAutoLinkProxyModules(generatedDir, stagedLibraries);
   return {
     modulePath: generatedModule,
@@ -146,13 +145,6 @@ function writeAutoLinkProxyModules(
   const aliases: Record<string, string> = {};
 
   for (const library of stagedLibraries) {
-    if (
-      library.copyMode !== 'package' ||
-      library.requireSpecifier === undefined
-    ) {
-      continue;
-    }
-
     const proxyPath = path.join(
       generatedDir,
       `${sanitizeProxyFileName(library.requireSpecifier)}.mjs`
@@ -174,7 +166,9 @@ import __path from 'node:path';
 import { fileURLToPath as __fileURLToPath } from 'node:url';
 
 const __lynxtronAutoLinkProxySourceDir = __path.dirname(
-  __fileURLToPath(import.meta.url),
+  typeof __filename === 'string'
+    ? __filename
+    : __fileURLToPath(import.meta.url),
 );
 const __lynxtronAutoLinkProxyPackageRoot = ${JSON.stringify(
     normalizeStagedPath(library.stagedPath)
@@ -291,8 +285,7 @@ function createLynxtronAutoLinkStagePlugin(
         stageAutoLinkLibraries(root, compiler.options.output?.path, options);
       };
 
-      compiler.hooks?.beforeRun?.tap('LynxtronAutoLinkStage', stage);
-      compiler.hooks?.watchRun?.tap('LynxtronAutoLinkStage', stage);
+      compiler.hooks?.afterEmit?.tap('LynxtronAutoLinkStage', stage);
     },
   };
 }
@@ -324,125 +317,49 @@ function stageAutoLinkLibraries(
   );
 
   for (const library of stagedLibraries) {
-    stageAutoLinkLibrary(outputPath, library, options);
+    stageAutoLinkLibrary(outputPath, library);
   }
 }
 
 function stageAutoLinkLibrary(
   outputPath: string,
-  library: LynxtronAutoLinkStagedLibrary,
-  options: LynxtronAutoLinkPluginOptions
-): void {
-  if (library.copyMode === 'package') {
-    stageAutoLinkPackage(outputPath, library, options);
-    return;
-  }
-
-  if (hasGlob(library.sourcePath)) {
-    options.warn?.(
-      `Lynxtron AutoLink cannot stage glob native library path: ${library.sourcePath}`
-    );
-    return;
-  }
-
-  if (!fs.existsSync(library.sourcePath)) {
-    return;
-  }
-
-  const targetPath = path.join(outputPath, library.stagedPath);
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.copyFileSync(library.sourcePath, targetPath);
-}
-
-function stageAutoLinkPackage(
-  outputPath: string,
-  library: LynxtronAutoLinkStagedLibrary,
-  options: LynxtronAutoLinkPluginOptions
+  library: LynxtronAutoLinkStagedLibrary
 ): void {
   if (!fs.existsSync(library.sourcePath)) {
     return;
   }
 
   const targetPath = path.join(outputPath, library.stagedPath);
-  const packageFiles = readPackageFiles(library.sourcePath);
 
   fs.rmSync(targetPath, { recursive: true, force: true });
   fs.mkdirSync(targetPath, { recursive: true });
-  copyPath(
-    path.join(library.sourcePath, 'package.json'),
-    path.join(targetPath, 'package.json')
-  );
-  copyPath(
-    path.join(library.sourcePath, 'lynx.lib.json'),
-    path.join(targetPath, 'lynx.lib.json')
-  );
 
-  if (packageFiles.length === 0) {
-    copyDirectory(library.sourcePath, targetPath);
-    return;
-  }
-
-  for (const entry of packageFiles) {
-    const normalizedEntry = normalizePackageFileEntry(entry);
-
-    if (normalizedEntry === undefined) {
-      options.warn?.(
-        `Lynxtron AutoLink cannot stage package file pattern: ${entry}`
-      );
-      continue;
-    }
-
+  for (const entry of library.files) {
     copyPath(
-      path.join(library.sourcePath, normalizedEntry),
-      path.join(targetPath, normalizedEntry)
+      path.join(library.sourcePath, entry),
+      path.join(targetPath, entry)
     );
   }
 }
 
-function readPackageFiles(packageRoot: string): string[] {
+function copyPath(sourcePath: string, targetPath: string): void {
+  let stat: fs.Stats;
   try {
-    const packageJson = JSON.parse(
-      fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8')
-    ) as { files?: unknown };
-
-    if (Array.isArray(packageJson.files)) {
-      return packageJson.files.filter(
-        (item): item is string =>
-          typeof item === 'string' && item.length > 0 && !item.startsWith('!')
-      );
+    stat = fs.lstatSync(sourcePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
     }
-  } catch {}
-
-  return [];
-}
-
-function normalizePackageFileEntry(entry: string): string | undefined {
-  const normalizedEntry = entry
-    .replaceAll('\\', '/')
-    .replace(/^\.\//, '')
-    .replace(/\/\*\*\/\*$/, '')
-    .replace(/\/\*$/, '');
-
-  if (
-    normalizedEntry.length === 0 ||
-    normalizedEntry.includes('..') ||
-    normalizedEntry.includes('*')
-  ) {
-    return undefined;
+    throw error;
   }
 
-  return normalizedEntry;
-}
-
-function copyPath(sourcePath: string, targetPath: string): void {
-  if (!fs.existsSync(sourcePath)) {
+  if (stat.isSymbolicLink()) {
+    copySymbolicLink(sourcePath, targetPath, path.dirname(sourcePath));
     return;
   }
 
-  const stat = fs.statSync(sourcePath);
-
   if (stat.isDirectory()) {
-    copyDirectory(sourcePath, targetPath);
+    copyDirectory(sourcePath, targetPath, sourcePath);
     return;
   }
 
@@ -450,7 +367,11 @@ function copyPath(sourcePath: string, targetPath: string): void {
   fs.copyFileSync(sourcePath, targetPath);
 }
 
-function copyDirectory(sourcePath: string, targetPath: string): void {
+function copyDirectory(
+  sourcePath: string,
+  targetPath: string,
+  sourceRoot = sourcePath
+): void {
   if (shouldSkipPackageEntry(path.basename(sourcePath))) {
     return;
   }
@@ -466,12 +387,37 @@ function copyDirectory(sourcePath: string, targetPath: string): void {
     const targetEntry = path.join(targetPath, entry.name);
 
     if (entry.isDirectory()) {
-      copyDirectory(sourceEntry, targetEntry);
+      copyDirectory(sourceEntry, targetEntry, sourceRoot);
+    } else if (entry.isSymbolicLink()) {
+      copySymbolicLink(sourceEntry, targetEntry, sourceRoot);
     } else if (entry.isFile()) {
       fs.mkdirSync(path.dirname(targetEntry), { recursive: true });
       fs.copyFileSync(sourceEntry, targetEntry);
     }
   }
+}
+
+function copySymbolicLink(
+  sourcePath: string,
+  targetPath: string,
+  sourceRoot: string
+): void {
+  const linkTarget = fs.readlinkSync(sourcePath);
+  const resolvedTarget = path.resolve(path.dirname(sourcePath), linkTarget);
+  const relativeTarget = path.relative(sourceRoot, resolvedTarget);
+
+  if (
+    path.isAbsolute(linkTarget) ||
+    relativeTarget === '..' ||
+    relativeTarget.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error(
+      `Lynxtron AutoLink refuses to stage symbolic link outside its package: ${sourcePath} -> ${linkTarget}`
+    );
+  }
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.symlinkSync(linkTarget, targetPath);
 }
 
 function shouldSkipPackageEntry(name: string): boolean {
@@ -483,10 +429,6 @@ function shouldSkipPackageEntry(name: string): boolean {
     name === '_tmp_extract' ||
     name.endsWith('.zip')
   );
-}
-
-function hasGlob(value: string): boolean {
-  return value.includes('*');
 }
 
 function prependAutoLinkEntry(

--- a/src/packages/lynxtron-dev-plugins/src/autolink.ts
+++ b/src/packages/lynxtron-dev-plugins/src/autolink.ts
@@ -13,21 +13,8 @@ const DEFAULT_DEPENDENCY_FIELDS = [
 ] as const;
 export const DEFAULT_LYNXTRON_NATIVE_OUTPUT_DIR = '.lynxtron/native';
 
-const PLATFORM_ALIASES: Record<string, string[]> = {
-  darwin: ['macos', 'darwin'],
-  macos: ['macos', 'darwin'],
-  win32: ['windows', 'win32'],
-  windows: ['windows', 'win32'],
-  linux: ['linux'],
-};
-
-const ARCH_ALIASES: Record<string, string[]> = {
-  arm64: ['arm64'],
-  x64: ['x64', 'x86_64'],
-  x86_64: ['x64', 'x86_64'],
-  ia32: ['ia32', 'x86'],
-  x86: ['ia32', 'x86'],
-};
+const MANIFEST_PLATFORMS = new Set(['darwin', 'win32', 'linux']);
+const MANIFEST_ARCHITECTURES = new Set(['arm64', 'x64', 'ia32']);
 
 export interface LynxtronAutoLinkOptions {
   root?: string;
@@ -37,24 +24,17 @@ export interface LynxtronAutoLinkOptions {
   warn?: (message: string) => void;
 }
 
-export interface LynxDesktopManifestEntry {
-  src?: string;
-  binary?: LynxNodeApiBinaryEntry | LynxNodeApiBinaryEntry[];
-}
-
 export interface LynxNodeApiManifestEntry {
-  path?: string | string[];
-  binary?: LynxNodeApiBinaryEntry | LynxNodeApiBinaryEntry[];
+  targets?: LynxtronRuntimeTarget[];
 }
 
-export interface LynxNodeApiBinaryEntry {
-  os?: string;
-  arch?: string;
-  arc?: string;
-  path?: string | string[];
+export interface LynxtronRuntimeTarget {
+  os: string;
+  arch: string;
+  files?: string[];
+  frameworks?: string[];
+  appBundles?: string[];
 }
-
-export type LynxtronAutoLinkStageMode = 'file' | 'package';
 
 export interface LynxtronAutoLinkLibrary {
   name: string;
@@ -64,10 +44,13 @@ export interface LynxtronAutoLinkLibrary {
   manifest: Record<string, unknown>;
   platformKey: string;
   archKey: string;
-  libs: string[];
-  libPaths: string[];
-  stageMode: LynxtronAutoLinkStageMode;
-  nodeModulesPath: string;
+  files: string[];
+  filePaths: string[];
+  frameworks: string[];
+  frameworkPaths: string[];
+  appBundles: string[];
+  appBundlePaths: string[];
+  entry: string;
   warnings: string[];
 }
 
@@ -79,23 +62,12 @@ export interface LynxtronAutoLinkResolution {
   warnings: string[];
 }
 
-export interface LynxtronAutoLinkFileSet {
-  from: string;
-  to: string;
-  filter: string[];
-}
-
 export interface LynxtronAutoLinkStagedLibrary {
   name: string;
   sourcePath: string;
   stagedPath: string;
-  requirePath: string;
-  requireSpecifier?: string;
-  copyMode: LynxtronAutoLinkStageMode;
-}
-
-export interface LynxtronAutoLinkCodegenOptions {
-  stagedLibraries?: LynxtronAutoLinkStagedLibrary[];
+  requireSpecifier: string;
+  files: string[];
 }
 
 interface PackageJson {
@@ -108,8 +80,9 @@ interface PackageJson {
 interface MatchedManifestEntry {
   platformKey: string;
   archKey: string;
-  libs: string[];
-  stageMode: LynxtronAutoLinkStageMode;
+  files: string[];
+  frameworks: string[];
+  appBundles: string[];
 }
 
 export function resolveLynxtronAutoLinks(
@@ -155,61 +128,72 @@ export function resolveLynxtronAutoLinks(
       continue;
     }
 
-    const libs = matchedEntry.libs.map((libraryPath) =>
-      expandManifestVariables(
-        libraryPath,
-        platform,
-        arch,
-        matchedEntry.platformKey,
-        matchedEntry.archKey
-      )
+    const files = matchedEntry.files;
+
+    const filePaths = files.map((filePath) =>
+      path.join(resolvedPackage.packageRoot, filePath)
+    );
+    const frameworks = matchedEntry.frameworks;
+    const frameworkPaths = frameworks.map((frameworkPath) =>
+      path.join(resolvedPackage.packageRoot, frameworkPath)
+    );
+    const appBundles = matchedEntry.appBundles;
+    const appBundlePaths = appBundles.map((appBundlePath) =>
+      path.join(resolvedPackage.packageRoot, appBundlePath)
     );
 
-    if (libs.length === 0) {
+    if (
+      files.length === 0 &&
+      frameworks.length === 0 &&
+      appBundles.length === 0
+    ) {
       continue;
     }
-
-    const libPaths = libs.map((libraryPath) =>
-      path.join(resolvedPackage.packageRoot, libraryPath)
-    );
     const libraryWarnings: string[] = [];
+    const requireFromPackage = createRequire(resolvedPackage.packageJsonPath);
+    const lynxtronSpecifier = getNodeApiPackageSpecifier(dependencyName);
+    let entry = '';
 
-    if (matchedEntry.stageMode === 'package') {
-      const requireFromPackage = createRequire(resolvedPackage.packageJsonPath);
-      const lynxtronSpecifier = getNodeApiPackageSpecifier(dependencyName);
-
-      try {
-        requireFromPackage.resolve(lynxtronSpecifier);
-      } catch {
+    try {
+      const entryPath = requireFromPackage.resolve(lynxtronSpecifier);
+      const relativeEntry = path.relative(
+        resolvedPackage.packageRoot,
+        entryPath
+      );
+      if (relativeEntry.startsWith('..') || path.isAbsolute(relativeEntry)) {
         libraryWarnings.push(
-          `Lynxtron AutoLink package "${dependencyName}" declares Lynxtron assets, but ${lynxtronSpecifier} cannot be resolved.`
+          `Lynxtron AutoLink package "${dependencyName}" resolves ${lynxtronSpecifier} outside its package.`
         );
+      } else {
+        entry = normalizeFilterPath(relativeEntry);
       }
-
-      for (const [index, libPath] of libPaths.entries()) {
-        if (hasGlob(libs[index])) {
-          continue;
-        }
-
-        if (!fs.existsSync(libPath)) {
-          libraryWarnings.push(
-            `Lynxtron AutoLink package "${dependencyName}" declares Lynxtron assets ${libs[index]}, but the path does not exist.`
-          );
-        }
-      }
-    } else {
-      for (const [index, libPath] of libPaths.entries()) {
-        if (hasGlob(libs[index])) {
-          continue;
-        }
-
-        if (!fs.existsSync(libPath)) {
-          libraryWarnings.push(
-            `Lynxtron AutoLink package "${dependencyName}" declares Node-API binary ${libs[index]}, but the file does not exist.`
-          );
-        }
-      }
+    } catch {
+      libraryWarnings.push(
+        `Lynxtron AutoLink package "${dependencyName}" declares Lynxtron assets, but ${lynxtronSpecifier} cannot be resolved.`
+      );
     }
+
+    validateArtifactPaths({
+      dependencyName,
+      kind: 'file',
+      paths: files,
+      absolutePaths: filePaths,
+      warnings: libraryWarnings,
+    });
+    validateArtifactPaths({
+      dependencyName,
+      kind: 'Framework',
+      paths: frameworks,
+      absolutePaths: frameworkPaths,
+      warnings: libraryWarnings,
+    });
+    validateArtifactPaths({
+      dependencyName,
+      kind: 'app bundle',
+      paths: appBundles,
+      absolutePaths: appBundlePaths,
+      warnings: libraryWarnings,
+    });
 
     for (const warning of libraryWarnings) {
       warnings.push(warning);
@@ -224,10 +208,13 @@ export function resolveLynxtronAutoLinks(
       manifest,
       platformKey: matchedEntry.platformKey,
       archKey: matchedEntry.archKey,
-      libs,
-      libPaths,
-      stageMode: matchedEntry.stageMode,
-      nodeModulesPath: packageNameToNodeModulesPath(dependencyName),
+      files,
+      filePaths,
+      frameworks,
+      frameworkPaths,
+      appBundles,
+      appBundlePaths,
+      entry,
       warnings: libraryWarnings,
     });
   }
@@ -241,27 +228,6 @@ export function resolveLynxtronAutoLinks(
   };
 }
 
-export function createLynxtronAutoLinkFileSets(
-  resolution: LynxtronAutoLinkResolution
-): LynxtronAutoLinkFileSet[] {
-  return resolution.libraries.map((library) => {
-    const filters =
-      library.stageMode === 'package'
-        ? ['package.json', 'lynx.lib.json', '**/*']
-        : [
-            'package.json',
-            'lynx.lib.json',
-            ...library.libs.map(normalizeFilterPath),
-          ];
-
-    return {
-      from: library.packageRoot,
-      to: library.nodeModulesPath,
-      filter: Array.from(new Set(filters)),
-    };
-  });
-}
-
 export function createLynxtronAutoLinkStagedLibraries(
   resolution: LynxtronAutoLinkResolution,
   nativeOutputDir = DEFAULT_LYNXTRON_NATIVE_OUTPUT_DIR
@@ -270,164 +236,32 @@ export function createLynxtronAutoLinkStagedLibraries(
   const stagedLibraries: LynxtronAutoLinkStagedLibrary[] = [];
 
   for (const library of resolution.libraries) {
-    if (library.stageMode === 'package') {
-      const stagedPackagePath = path.posix.join(
-        outputRoot,
-        packageNameToNodeModulesPath(library.name)
-      );
+    const stagedPackagePath = path.posix.join(
+      outputRoot,
+      packageNameToNodeModulesPath(library.name)
+    );
 
-      stagedLibraries.push({
-        name: library.name,
-        sourcePath: library.packageRoot,
-        stagedPath: stagedPackagePath,
-        requirePath: stagedPackagePath,
-        requireSpecifier: getNodeApiPackageSpecifier(library.name),
-        copyMode: 'package',
-      });
-      continue;
-    }
-
-    for (const [index, sourcePath] of library.libPaths.entries()) {
-      const stagedPath = path.posix.join(
-        outputRoot,
-        packageNameToNodeModulesPath(library.name),
-        normalizeFilterPath(library.libs[index])
-      );
-
-      stagedLibraries.push({
-        name: library.name,
-        sourcePath,
-        stagedPath,
-        requirePath: stagedPath,
-        copyMode: 'file',
-      });
-    }
+    stagedLibraries.push({
+      name: library.name,
+      sourcePath: library.packageRoot,
+      stagedPath: stagedPackagePath,
+      requireSpecifier: getNodeApiPackageSpecifier(library.name),
+      files: getAutoLinkPackageFiles(library),
+    });
   }
 
   return stagedLibraries;
 }
 
-export function generateLynxtronAutoLinkCode(
-  resolution: LynxtronAutoLinkResolution,
-  options: LynxtronAutoLinkCodegenOptions = {}
-): string {
-  if (options.stagedLibraries !== undefined) {
-    return generateLynxtronAutoLinkStagedCode(options.stagedLibraries);
-  }
-
-  if (resolution.libraries.length === 0) {
-    return 'export {};\n';
-  }
-
-  const records = resolution.libraries.map(
-    (library) =>
-      `  { packageName: ${JSON.stringify(library.name)}, libs: ${JSON.stringify(
-        library.libs
-      )}, stageMode: ${JSON.stringify(
-        library.stageMode
-      )}, specifier: ${JSON.stringify(
-        library.stageMode === 'package'
-          ? getNodeApiPackageSpecifier(library.name)
-          : undefined
-      )} },`
-  );
-
-  return `import __fs from 'node:fs';
-import { createRequire as __createRequire } from 'node:module';
-import __path from 'node:path';
-
-const __lynxtronAutoLinkRequire = typeof __non_webpack_require__ === 'function'
-  ? __non_webpack_require__
-  : __createRequire(import.meta.url);
-const __lynxtronAutoLinkNodeApiAddons = new Set();
-
-const __lynxtronAutoLinkLibraries = [
-${records.join('\n')}
-];
-
-function __lynxtronAutoLinkResolvePackageRoot(packageName) {
-  try {
-    return __path.dirname(
-      __lynxtronAutoLinkRequire.resolve(\`\${packageName}/package.json\`),
-    );
-  } catch {}
-
-  const entryPath = __lynxtronAutoLinkRequire.resolve(packageName);
-  let current = __fs.statSync(entryPath).isDirectory()
-    ? entryPath
-    : __path.dirname(entryPath);
-
-  while (true) {
-    const packageJsonPath = __path.join(current, 'package.json');
-
-    if (__fs.existsSync(packageJsonPath)) {
-      try {
-        const packageJson = JSON.parse(
-          __fs.readFileSync(packageJsonPath, 'utf8'),
-        );
-
-        if (packageJson && packageJson.name === packageName) {
-          return current;
-        }
-      } catch {}
-    }
-
-    const parent = __path.dirname(current);
-
-    if (parent === current) {
-      throw new Error(
-        \`Cannot resolve AutoLink package root for \${packageName}\`,
-      );
-    }
-
-    current = parent;
-  }
-}
-
-function __lynxtronAutoLinkLoadNodeApiAddon(libraryPath, isPackageEntry) {
-  const loadPath = isPackageEntry
-    ? __lynxtronAutoLinkRequire.resolve(libraryPath)
-    : __path.resolve(libraryPath);
-
-  if (__lynxtronAutoLinkNodeApiAddons.has(loadPath)) {
-    return;
-  }
-
-  __lynxtronAutoLinkRequire(isPackageEntry ? libraryPath : loadPath);
-  __lynxtronAutoLinkNodeApiAddons.add(loadPath);
-}
-
-for (const __lynxtronAutoLinkRecord of __lynxtronAutoLinkLibraries) {
-  let __lynxtronAutoLinkPackageRoot;
-
-  if (__lynxtronAutoLinkRecord.stageMode === 'package') {
-    __lynxtronAutoLinkLoadNodeApiAddon(
-      __lynxtronAutoLinkRecord.specifier,
-      true,
-    );
-    continue;
-  }
-
-  for (const __lynxtronAutoLinkLib of __lynxtronAutoLinkRecord.libs) {
-    __lynxtronAutoLinkPackageRoot ??= __lynxtronAutoLinkResolvePackageRoot(
-      __lynxtronAutoLinkRecord.packageName,
-    );
-    __lynxtronAutoLinkLoadNodeApiAddon(
-      __path.join(__lynxtronAutoLinkPackageRoot, __lynxtronAutoLinkLib),
-      false,
-    );
-  }
-}
-`;
-}
-
 export function writeLynxtronAutoLinkModule(
-  resolution: LynxtronAutoLinkResolution,
   filePath: string,
-  options: LynxtronAutoLinkCodegenOptions = {}
+  stagedLibraries: LynxtronAutoLinkStagedLibrary[]
 ): string {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, generateLynxtronAutoLinkCode(resolution, options));
+  fs.writeFileSync(
+    filePath,
+    generateLynxtronAutoLinkStagedCode(stagedLibraries)
+  );
   return filePath;
 }
 
@@ -440,11 +274,7 @@ function generateLynxtronAutoLinkStagedCode(
 
   const records = stagedLibraries.map(
     (library) =>
-      `  { copyMode: ${JSON.stringify(
-        library.copyMode
-      )}, path: ${JSON.stringify(
-        normalizeFilterPath(library.requirePath)
-      )}, packageRoot: ${JSON.stringify(
+      `  { packageRoot: ${JSON.stringify(
         normalizeFilterPath(library.stagedPath)
       )}, packageName: ${JSON.stringify(
         library.name
@@ -458,9 +288,13 @@ import { fileURLToPath as __fileURLToPath } from 'node:url';
 
 const __lynxtronAutoLinkRequire = typeof __non_webpack_require__ === 'function'
   ? __non_webpack_require__
-  : __createRequire(import.meta.url);
+  : __createRequire(
+      typeof __filename === 'string' ? __filename : import.meta.url,
+    );
 const __lynxtronAutoLinkSourceDir = __path.dirname(
-  __fileURLToPath(import.meta.url),
+  typeof __filename === 'string'
+    ? __filename
+    : __fileURLToPath(import.meta.url),
 );
 const __lynxtronAutoLinkNodeApiAddons = new Set();
 const __lynxtronAutoLinkLibraries = [
@@ -469,20 +303,16 @@ ${records.join('\n')}
 
 function __lynxtronAutoLinkLoadNodeApiAddon(library) {
   const loadPath = __lynxtronAutoLinkResolveExistingLoadPath(
-    library.copyMode === 'package' ? library.packageRoot : library.path,
+    library.packageRoot,
   );
 
   if (__lynxtronAutoLinkNodeApiAddons.has(loadPath)) {
     return;
   }
 
-  if (library.copyMode === 'package') {
-    __lynxtronAutoLinkRegisterNodeModulesRoot(loadPath, library.packageName);
-    const packageRequire = __createRequire(__path.join(loadPath, 'package.json'));
-    packageRequire(library.specifier);
-  } else {
-    __lynxtronAutoLinkRequire(loadPath);
-  }
+  __lynxtronAutoLinkRegisterNodeModulesRoot(loadPath, library.packageName);
+  const packageRequire = __createRequire(__path.join(loadPath, 'package.json'));
+  packageRequire(library.specifier);
 
   __lynxtronAutoLinkNodeApiAddons.add(loadPath);
 }
@@ -665,32 +495,11 @@ function getNodeApiManifestEntry(
     return undefined;
   }
 
-  const platformRecords = platforms as Record<string, unknown>;
-
-  const nodeApiEntry = matchNodeApiManifestEntry(
-    platformRecords['lynxtron'],
+  return matchNodeApiManifestEntry(
+    (platforms as Record<string, unknown>)['lynxtron'],
     platform,
     arch
   );
-
-  if (nodeApiEntry !== undefined) {
-    return nodeApiEntry;
-  }
-
-  for (const platformKey of getManifestKeys(platform, PLATFORM_ALIASES)) {
-    const matchedEntry = matchBinaryManifestEntry(
-      platformKey,
-      platformRecords[platformKey],
-      platform,
-      arch
-    );
-
-    if (matchedEntry !== undefined) {
-      return matchedEntry;
-    }
-  }
-
-  return undefined;
 }
 
 function matchNodeApiManifestEntry(
@@ -703,120 +512,195 @@ function matchNodeApiManifestEntry(
   }
 
   const nodeApiEntry = platformEntry as LynxNodeApiManifestEntry;
-  const paths = normalizeLibraryPaths(nodeApiEntry.path);
-
-  if (paths.length > 0) {
-    return {
-      platformKey: 'lynxtron',
-      archKey: runtimeArch,
-      libs: paths,
-      stageMode: 'package',
-    };
-  }
-
-  return matchBinaryManifestEntry(
-    'lynxtron',
-    platformEntry,
+  const target = matchRuntimeTarget(
+    nodeApiEntry.targets,
     runtimePlatform,
     runtimeArch
   );
-}
-
-function matchBinaryManifestEntry(
-  platformKey: string,
-  platformEntry: unknown,
-  runtimePlatform: string,
-  runtimeArch: string
-): MatchedManifestEntry | undefined {
-  if (platformEntry === null || typeof platformEntry !== 'object') {
+  if (target === undefined) {
     return undefined;
   }
 
-  const desktopEntry = platformEntry as LynxDesktopManifestEntry;
+  if (
+    'binary' in target.entry ||
+    'binaries' in target.entry ||
+    'resources' in target.entry
+  ) {
+    throw new Error(
+      'Lynxtron AutoLink does not support binary, binaries, or resources in targets; use files.'
+    );
+  }
 
-  for (const binaryEntry of normalizeBinaryEntries(desktopEntry.binary)) {
-    const os = readOptionalString(binaryEntry.os);
-    const binaryArch =
-      readOptionalString(binaryEntry.arch) ??
-      readOptionalString(binaryEntry.arc);
-    const binaryPaths = normalizeLibraryPaths(binaryEntry.path);
+  const frameworks = normalizeLibraryPaths(target.entry.frameworks);
+  if (frameworks.length > 0) {
+    if (runtimePlatform !== 'darwin') {
+      throw new Error(
+        'Lynxtron AutoLink only supports frameworks for darwin targets.'
+      );
+    }
+    if (frameworks.some((framework) => !framework.endsWith('.framework'))) {
+      throw new Error(
+        'Lynxtron AutoLink requires every frameworks path to end in .framework.'
+      );
+    }
+  }
 
+  const appBundles = normalizeLibraryPaths(target.entry.appBundles);
+  if (appBundles.length > 0) {
+    if (runtimePlatform !== 'darwin') {
+      throw new Error(
+        'Lynxtron AutoLink only supports appBundles for darwin targets.'
+      );
+    }
+    if (appBundles.some((appBundle) => !appBundle.endsWith('.app'))) {
+      throw new Error(
+        'Lynxtron AutoLink requires every appBundles path to end in .app.'
+      );
+    }
+  }
+
+  return {
+    platformKey: 'lynxtron',
+    archKey: target.archKey,
+    files: normalizeLibraryPaths(target.entry.files),
+    frameworks,
+    appBundles,
+  };
+}
+
+function matchRuntimeTarget(
+  targets: unknown,
+  runtimePlatform: string,
+  runtimeArch: string
+): { archKey: string; entry: LynxtronRuntimeTarget } | undefined {
+  const matches: Array<{
+    archKey: string;
+    entry: LynxtronRuntimeTarget;
+  }> = [];
+
+  for (const target of normalizeRuntimeTargets(targets)) {
+    const { os, arch: targetArch } = target;
     if (
-      os === undefined ||
-      binaryArch === undefined ||
-      binaryPaths.length === 0 ||
-      !matchesManifestKey(runtimePlatform, os, PLATFORM_ALIASES) ||
-      !matchesManifestKey(runtimeArch, binaryArch, ARCH_ALIASES)
+      !MANIFEST_PLATFORMS.has(os) ||
+      !MANIFEST_ARCHITECTURES.has(targetArch)
     ) {
+      throw new Error(
+        `Lynxtron AutoLink requires standard os/arch names, got ${os}/${targetArch}.`
+      );
+    }
+    // Validate every declaration, including targets not selected on this host.
+    for (const field of ['files', 'frameworks', 'appBundles'] as const) {
+      normalizeLibraryPaths(target[field]);
+    }
+    if (runtimePlatform !== os || runtimeArch !== targetArch) {
       continue;
     }
 
-    return {
-      platformKey,
-      archKey: binaryArch,
-      libs: binaryPaths,
-      stageMode: 'file',
-    };
+    matches.push({
+      archKey: targetArch,
+      entry: target,
+    });
   }
 
-  return undefined;
+  if (matches.length > 1) {
+    throw new Error(
+      `Lynxtron AutoLink found duplicate targets for ${runtimePlatform}/${runtimeArch}.`
+    );
+  }
+
+  return matches[0];
 }
 
-function normalizeBinaryEntries(value: unknown): LynxNodeApiBinaryEntry[] {
-  const values = Array.isArray(value) ? value : [value];
-  const entries: LynxNodeApiBinaryEntry[] = [];
+function normalizeRuntimeTargets(value: unknown): LynxtronRuntimeTarget[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
 
-  for (const item of values) {
+  const entries: LynxtronRuntimeTarget[] = [];
+
+  for (const item of value) {
     if (item !== null && typeof item === 'object') {
-      entries.push(item as LynxNodeApiBinaryEntry);
+      entries.push(item as LynxtronRuntimeTarget);
     }
   }
 
   return entries;
 }
 
-function getManifestKeys(
-  value: string,
-  aliases: Record<string, string[]>
-): string[] {
-  return Array.from(new Set(aliases[value] ?? [value]));
-}
-
-function matchesManifestKey(
-  runtimeValue: string,
-  manifestValue: string,
-  aliases: Record<string, string[]>
-): boolean {
-  return getManifestKeys(runtimeValue, aliases).includes(manifestValue);
-}
-
 function normalizeLibraryPaths(value: unknown): string[] {
-  const values = Array.isArray(value) ? value : [value];
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(
+      'Lynxtron AutoLink artifact paths must be non-empty arrays.'
+    );
+  }
+  const values = value;
   const paths: string[] = [];
 
   for (const item of values) {
     const libraryPath = normalizeRelativePath(item);
 
-    if (libraryPath !== undefined) {
-      paths.push(libraryPath);
+    if (
+      !libraryPath ||
+      libraryPath.includes('${') ||
+      /[*?\[\]{}]/.test(libraryPath)
+    ) {
+      throw new Error(
+        `Lynxtron AutoLink requires fixed package-relative artifact paths, got ${String(
+          item
+        )}.`
+      );
     }
+    paths.push(libraryPath);
   }
 
   return paths;
 }
 
-function expandManifestVariables(
-  value: string,
-  platform: string,
-  arch: string,
-  manifestPlatform: string,
-  manifestArch: string
-): string {
-  return value
-    .replaceAll('${platform}', platform)
-    .replaceAll('${arch}', arch)
-    .replaceAll('${manifestPlatform}', manifestPlatform)
-    .replaceAll('${manifestArch}', manifestArch);
+function validateArtifactPaths({
+  dependencyName,
+  kind,
+  paths,
+  absolutePaths,
+  warnings,
+}: {
+  dependencyName: string;
+  kind: string;
+  paths: string[];
+  absolutePaths: string[];
+  warnings: string[];
+}): void {
+  for (const [index, absolutePath] of absolutePaths.entries()) {
+    if (hasGlob(paths[index])) {
+      warnings.push(
+        `Lynxtron AutoLink package "${dependencyName}" declares unsupported ${kind} glob ${paths[index]}.`
+      );
+      continue;
+    }
+
+    if (!fs.existsSync(absolutePath)) {
+      warnings.push(
+        `Lynxtron AutoLink package "${dependencyName}" declares ${kind} assets ${paths[index]}, but the path does not exist.`
+      );
+    }
+  }
+}
+
+function getAutoLinkPackageFiles(library: LynxtronAutoLinkLibrary): string[] {
+  return Array.from(
+    new Set(
+      [
+        'package.json',
+        'lynx.lib.json',
+        library.entry,
+        ...library.files,
+        ...library.frameworks,
+        ...library.appBundles,
+      ]
+        .filter((entry) => entry.length > 0 && !hasGlob(entry))
+        .map(normalizeFilterPath)
+    )
+  );
 }
 
 function packageNameToNodeModulesPath(packageName: string): string {
@@ -832,11 +716,16 @@ function normalizeRelativePath(value: unknown): string | undefined {
     return undefined;
   }
 
-  return value.replaceAll('\\', '/').replace(/^\.\//, '');
-}
+  const normalizedPath = value.replaceAll('\\', '/').replace(/^\.\//, '');
+  if (
+    path.posix.isAbsolute(normalizedPath) ||
+    /^[A-Za-z]:\//.test(normalizedPath) ||
+    normalizedPath.split('/').includes('..')
+  ) {
+    return undefined;
+  }
 
-function readOptionalString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
+  return normalizedPath;
 }
 
 function normalizeFilterPath(value: string): string {

--- a/src/packages/lynxtron-dev-plugins/src/rspack.ts
+++ b/src/packages/lynxtron-dev-plugins/src/rspack.ts
@@ -49,7 +49,10 @@ const restartLynxtron = debounce(
       } catch {}
 
       const { entry, args = [], env = {}, command = 'lynxtron' } = options;
-      const spawnArgs = [...args, entry];
+      // The Lynxtron runtime treats argv[1] as the application directory.
+      // Keep it first so runtime flags cannot be mistaken for the app path by
+      // the runtime or generated AutoLink loaders.
+      const spawnArgs = [entry, ...args];
 
       lynxtronProcess = spawn(command, spawnArgs, {
         stdio: 'inherit',

--- a/src/packages/lynxtron-dev-plugins/test/manifest-contract.test.js
+++ b/src/packages/lynxtron-dev-plugins/test/manifest-contract.test.js
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { resolveLynxtronAutoLinks } from '../dist/autolink.js';
+import { applyLynxtronAutoLink } from '../dist/autolink-rspack.js';
+
+function fixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lynxtron-manifest-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const pkg = path.join(root, 'node_modules', 'fixture');
+  fs.mkdirSync(path.join(pkg, 'dist'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ dependencies: { fixture: '1.0.0' } })
+  );
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify({
+      name: 'fixture',
+      exports: {
+        '.': './index.cjs',
+        './package.json': './package.json',
+        './lynxtron': './index.cjs',
+      },
+    })
+  );
+  fs.writeFileSync(path.join(pkg, 'index.cjs'), 'module.exports = {};');
+  fs.writeFileSync(path.join(pkg, 'dist/addon.node'), 'fixture');
+  const manifest = {
+    platforms: {
+      lynxtron: {
+        targets: [
+          { os: 'darwin', arch: 'arm64', files: ['dist/addon.node'] },
+          { os: 'win32', arch: 'x64', files: ['dist/addon.node'] },
+        ],
+      },
+    },
+  };
+  return {
+    root,
+    pkg,
+    manifest,
+    write() {
+      fs.writeFileSync(
+        path.join(pkg, 'lynx.lib.json'),
+        JSON.stringify(manifest)
+      );
+    },
+  };
+}
+
+for (const [platform, arch] of [
+  ['darwin', 'arm64'],
+  ['win32', 'x64'],
+]) {
+  test(`fixed manifest survives resolve and stage unchanged: ${platform}/${arch}`, (t) => {
+    const f = fixture(t);
+    f.write();
+    const original = fs.readFileSync(path.join(f.pkg, 'lynx.lib.json'), 'utf8');
+    const output = path.join(f.root, 'output');
+    let afterEmit;
+    applyLynxtronAutoLink(
+      {
+        context: f.root,
+        options: {
+          target: 'electron-main',
+          entry: './main.js',
+          output: { path: output },
+        },
+        hooks: {
+          afterEmit: {
+            tap(_name, fn) {
+              afterEmit = fn;
+            },
+          },
+        },
+      },
+      { platform, arch }
+    );
+    afterEmit();
+    assert.equal(
+      fs.readFileSync(path.join(f.pkg, 'lynx.lib.json'), 'utf8'),
+      original
+    );
+    assert.equal(
+      fs.readFileSync(
+        path.join(
+          output,
+          '.lynxtron/native/node_modules/fixture/lynx.lib.json'
+        ),
+        'utf8'
+      ),
+      original
+    );
+  });
+}
+
+const invalid = [
+  [
+    'outside package',
+    (target) => {
+      target.files = ['../outside'];
+    },
+    /fixed package-relative/,
+  ],
+  [
+    'glob path',
+    (target) => {
+      target.files = ['dist/*.node'];
+    },
+    /fixed package-relative/,
+  ],
+  [
+    'platform alias',
+    (target) => {
+      target.os = 'macos';
+    },
+    /standard os\/arch/,
+  ],
+  [
+    'Windows alias',
+    (target) => {
+      target.os = 'windows';
+    },
+    /standard os\/arch/,
+  ],
+  [
+    'architecture alias',
+    (target) => {
+      target.arch = 'x86_64';
+    },
+    /standard os\/arch/,
+  ],
+  [
+    'x86 alias',
+    (target) => {
+      target.arch = 'x86';
+    },
+    /standard os\/arch/,
+  ],
+  ...['files', 'frameworks', 'appBundles'].flatMap((field) =>
+    ['platform', 'arch', 'manifestPlatform', 'manifestArch'].map((variable) => [
+      `${field} variable ${variable}`,
+      (target) => {
+        target[field] = ['dist/${' + variable + '}/artifact'];
+      },
+      /fixed package-relative/,
+    ])
+  ),
+];
+
+for (const [name, mutate, error] of invalid) {
+  test(`dev-plugin rejects ${name}, even in an unselected target`, (t) => {
+    const f = fixture(t);
+    mutate(f.manifest.platforms.lynxtron.targets[1]);
+    f.write();
+    assert.throws(
+      () =>
+        resolveLynxtronAutoLinks({
+          root: f.root,
+          platform: 'darwin',
+          arch: 'arm64',
+        }),
+      error
+    );
+  });
+}

--- a/src/packages/lynxtron-dev-plugins/test/rspack.test.js
+++ b/src/packages/lynxtron-dev-plugins/test/rspack.test.js
@@ -33,20 +33,22 @@ async function verifySpaceContainingArguments(modulePath) {
     await fs.mkdir(binDir, { recursive: true });
     await fs.writeFile(
       helperPath,
-      "import fs from 'node:fs'; fs.writeFileSync(process.env.LYNXTRON_TEST_OUTPUT, JSON.stringify(process.argv.slice(2)));\n",
+      "import fs from 'node:fs'; fs.writeFileSync(process.env.LYNXTRON_TEST_OUTPUT, JSON.stringify(process.argv.slice(2)));\n"
     );
 
     if (process.platform === 'win32') {
       await fs.writeFile(
         path.join(binDir, 'lynxtron.cmd'),
-        `@echo off\r\n"${process.execPath}" "${helperPath}" %*\r\n`,
+        `@echo off\r\n"${process.execPath}" "${helperPath}" %*\r\n`
       );
     } else {
       const quoteForShell = (value) => `'${value.replaceAll("'", "'\\''")}'`;
       const shimPath = path.join(binDir, 'lynxtron');
       await fs.writeFile(
         shimPath,
-        `#!/bin/sh\nexec ${quoteForShell(process.execPath)} ${quoteForShell(helperPath)} "$@"\n`,
+        `#!/bin/sh\nexec ${quoteForShell(process.execPath)} ${quoteForShell(
+          helperPath
+        )} "$@"\n`
       );
       await fs.chmod(shimPath, 0o755);
     }
@@ -79,9 +81,9 @@ async function verifySpaceContainingArguments(modulePath) {
     doneCallback();
 
     assert.deepEqual(await waitForJson(outputPath), [
+      entry,
       '--label',
       'value with spaces',
-      entry,
     ]);
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
@@ -90,12 +92,423 @@ async function verifySpaceContainingArguments(modulePath) {
 
 test('rspack plugin resolves the npm shim and preserves spaces in arguments', async () => {
   await verifySpaceContainingArguments(
-    path.resolve(import.meta.dirname, '../dist/rspack.js'),
+    path.resolve(import.meta.dirname, '../dist/rspack.js')
   );
 });
 
 test('legacy plugin entry resolves the npm shim and preserves spaces in arguments', async () => {
   await verifySpaceContainingArguments(
-    path.resolve(import.meta.dirname, '../index.js'),
+    path.resolve(import.meta.dirname, '../index.js')
   );
+});
+
+test('AutoLink stages native packages after the output directory is cleaned', async () => {
+  const tempDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'lynxtron-autolink-')
+  );
+  const packageName = 'fixture-native-library';
+  const packageRoot = path.join(tempDir, 'node_modules', packageName);
+  const outputPath = path.join(tempDir, 'dist');
+  const stagedPackageRoot = path.join(
+    outputPath,
+    '.lynxtron',
+    'native',
+    'node_modules',
+    packageName
+  );
+
+  try {
+    await fs.mkdir(path.join(packageRoot, 'dist', 'runtime'), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(packageRoot, 'dist', 'Fixture.framework'), {
+      recursive: true,
+    });
+    await fs.mkdir(
+      path.join(
+        packageRoot,
+        'dist',
+        'app-bundles',
+        'LynxtronWebview Helper.app',
+        'Contents',
+        'MacOS'
+      ),
+      { recursive: true }
+    );
+    await fs.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-app',
+        private: true,
+        dependencies: { [packageName]: '1.0.0' },
+      })
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        version: '1.0.0',
+        main: 'index.cjs',
+        exports: {
+          '.': './index.cjs',
+          './lynxtron': './index.cjs',
+        },
+        files: ['index.cjs', 'lynx.lib.json', 'dist/**/*'],
+      })
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'index.cjs'),
+      'module.exports = {};\n'
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'lynx.lib.json'),
+      JSON.stringify({
+        platforms: {
+          lynxtron: {
+            targets: [
+              {
+                os: process.platform,
+                arch: process.arch,
+                files: ['dist/native.node', 'dist/runtime'],
+                ...(process.platform === 'darwin'
+                  ? {
+                      frameworks: ['dist/Fixture.framework'],
+                      appBundles: [
+                        'dist/app-bundles/LynxtronWebview Helper.app',
+                      ],
+                    }
+                  : {}),
+              },
+            ],
+          },
+        },
+      })
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'dist', 'native.node'),
+      'fixture'
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'dist', 'native-win.node'),
+      'fixture-win32'
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'dist', 'runtime', 'runtime.dat'),
+      'runtime'
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'dist', 'Fixture.framework', 'framework.bin'),
+      'framework'
+    );
+    await fs.writeFile(
+      path.join(
+        packageRoot,
+        'dist',
+        'app-bundles',
+        'LynxtronWebview Helper.app',
+        'Contents',
+        'MacOS',
+        'LynxtronWebview Helper'
+      ),
+      'helper'
+    );
+    if (process.platform === 'darwin') {
+      await fs.symlink(
+        'framework.bin',
+        path.join(packageRoot, 'dist', 'Fixture.framework', 'framework-link')
+      );
+    }
+
+    const callbacks = new Map();
+    const hook = (name) => ({
+      tap(_pluginName, callback) {
+        callbacks.set(name, callback);
+      },
+    });
+    const compiler = {
+      context: tempDir,
+      options: {
+        target: 'electron-main',
+        entry: { main: path.join(tempDir, 'main.js') },
+        output: { path: outputPath },
+        plugins: [],
+      },
+      hooks: {
+        beforeRun: hook('beforeRun'),
+        watchRun: hook('watchRun'),
+        afterEmit: hook('afterEmit'),
+        done: hook('done'),
+      },
+    };
+
+    const { pluginLynxtron } = await import(
+      pathToFileURL(path.resolve(import.meta.dirname, '../dist/rspack.js')).href
+    );
+    pluginLynxtron({ isDev: false }).apply(compiler);
+
+    const generatedDir = path.join(
+      tempDir,
+      'node_modules',
+      '.cache',
+      'lynxtron-dev-plugins',
+      'autolink'
+    );
+    const generatedFiles = await fs.readdir(generatedDir);
+    for (const generatedFile of generatedFiles.filter((file) =>
+      file.endsWith('.mjs')
+    )) {
+      assert.match(
+        await fs.readFile(path.join(generatedDir, generatedFile), 'utf8'),
+        /typeof __filename === 'string'/
+      );
+    }
+
+    callbacks.get('beforeRun')();
+    await assert.rejects(fs.access(stagedPackageRoot));
+
+    // Rsbuild cleans the output after beforeRun and before Rspack emits files.
+    await fs.rm(outputPath, { recursive: true, force: true });
+    await fs.mkdir(outputPath, { recursive: true });
+    await fs.writeFile(path.join(outputPath, 'main.js'), '');
+    callbacks.get('afterEmit')();
+
+    assert.equal(
+      await fs.readFile(
+        path.join(stagedPackageRoot, 'dist', 'runtime', 'runtime.dat'),
+        'utf8'
+      ),
+      'runtime'
+    );
+    await assert.rejects(
+      fs.access(path.join(stagedPackageRoot, 'dist', 'native-win.node'))
+    );
+    assert.equal(
+      await fs.readFile(
+        path.join(stagedPackageRoot, 'dist', 'native.node'),
+        'utf8'
+      ),
+      'fixture'
+    );
+    if (process.platform === 'darwin') {
+      assert.equal(
+        await fs.readFile(
+          path.join(
+            stagedPackageRoot,
+            'dist',
+            'app-bundles',
+            'LynxtronWebview Helper.app',
+            'Contents',
+            'MacOS',
+            'LynxtronWebview Helper'
+          ),
+          'utf8'
+        ),
+        'helper'
+      );
+      assert.equal(
+        await fs.readlink(
+          path.join(
+            stagedPackageRoot,
+            'dist',
+            'Fixture.framework',
+            'framework-link'
+          )
+        ),
+        'framework.bin'
+      );
+    }
+
+    // Watch rebuilds must restore staging after another output clean as well.
+    callbacks.get('watchRun')();
+    await fs.rm(path.join(outputPath, '.lynxtron'), {
+      recursive: true,
+      force: true,
+    });
+    callbacks.get('afterEmit')();
+    assert.equal(
+      await fs.readFile(
+        path.join(stagedPackageRoot, 'dist', 'native.node'),
+        'utf8'
+      ),
+      'fixture'
+    );
+    if (process.platform === 'darwin') {
+      assert.equal(
+        await fs.readlink(
+          path.join(
+            stagedPackageRoot,
+            'dist',
+            'Fixture.framework',
+            'framework-link'
+          )
+        ),
+        'framework.bin'
+      );
+    }
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('AutoLink accepts only the prerelease Lynxtron artifact schema', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lynxtron-schema-'));
+  const packageName = 'fixture-native-library';
+  const packageRoot = path.join(tempDir, 'node_modules', packageName);
+  const manifestPath = path.join(packageRoot, 'lynx.lib.json');
+
+  try {
+    await fs.mkdir(path.join(packageRoot, 'dist'), { recursive: true });
+    await fs.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'fixture-app',
+        private: true,
+        dependencies: { [packageName]: '1.0.0' },
+      })
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'package.json'),
+      JSON.stringify({ name: packageName, version: '1.0.0' })
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'dist', 'native.node'),
+      'fixture'
+    );
+    await fs.writeFile(
+      path.join(packageRoot, 'dist', 'native-win.node'),
+      'fixture-win32'
+    );
+    await fs.mkdir(path.join(packageRoot, 'dist', 'Fixture.framework'));
+    await fs.mkdir(path.join(packageRoot, 'dist', 'frameworks-win'));
+
+    const { resolveLynxtronAutoLinks } = await import(
+      pathToFileURL(path.resolve(import.meta.dirname, '../dist/autolink.js'))
+        .href
+    );
+
+    await fs.writeFile(
+      manifestPath,
+      JSON.stringify({
+        platforms: {
+          lynxtron: {
+            targets: [
+              {
+                os: 'darwin',
+                arch: 'arm64',
+                files: ['dist/native.node', 'dist/frameworks'],
+                frameworks: ['dist/Fixture.framework'],
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    assert.deepEqual(
+      resolveLynxtronAutoLinks({
+        root: tempDir,
+        platform: 'darwin',
+        arch: 'arm64',
+      }).libraries.map(({ files, frameworks }) => ({ files, frameworks })),
+      [
+        {
+          files: ['dist/native.node', 'dist/frameworks'],
+          frameworks: ['dist/Fixture.framework'],
+        },
+      ]
+    );
+
+    await fs.writeFile(
+      manifestPath,
+      JSON.stringify({
+        platforms: {
+          lynxtron: {
+            targets: [
+              {
+                os: 'darwin',
+                arch: 'arm64',
+                files: ['dist/native.node'],
+              },
+              {
+                os: 'win32',
+                arch: 'x64',
+                files: ['dist/native-win.node', 'dist/frameworks-win'],
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    assert.deepEqual(
+      resolveLynxtronAutoLinks({
+        root: tempDir,
+        platform: 'win32',
+        arch: 'x64',
+      }).libraries.map(({ files, frameworks }) => ({
+        files,
+        frameworks,
+      })),
+      [
+        {
+          files: ['dist/native-win.node', 'dist/frameworks-win'],
+          frameworks: [],
+        },
+      ]
+    );
+
+    await fs.writeFile(
+      manifestPath,
+      JSON.stringify({
+        platforms: {
+          lynxtron: {
+            targets: [
+              {
+                os: process.platform,
+                arch: process.arch,
+                binaries: ['dist/native.node'],
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    assert.throws(
+      () => resolveLynxtronAutoLinks({ root: tempDir }),
+      /does not support binary, binaries, or resources.*use files/
+    );
+
+    await fs.writeFile(
+      manifestPath,
+      JSON.stringify({
+        platforms: {
+          lynxtron: {
+            binary: {
+              os: process.platform,
+              arc: process.arch,
+              path: 'dist/native.node',
+            },
+          },
+        },
+      })
+    );
+
+    assert.equal(
+      resolveLynxtronAutoLinks({ root: tempDir }).libraries.length,
+      0
+    );
+
+    await fs.writeFile(
+      manifestPath,
+      JSON.stringify({ platforms: { lynxtron: { path: 'dist' } } })
+    );
+
+    assert.equal(
+      resolveLynxtronAutoLinks({ root: tempDir }).libraries.length,
+      0
+    );
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Scope and dependency
Third extraction from #234: AutoLink development integration only.
Rebased onto main at 313b679bbff44777aa3002837624a72aa5856861 after #252 and #253 merged. Targets main and contains only one AutoLink commit; range-diff confirms the original AutoLink patch is unchanged.

## Changes
- Register the CEF webview with the native AutoLink registration API.
- Declare literal target-specific files, frameworks and appBundles in lynx.lib.json; select addon paths from that manifest.
- Select and validate the prerelease target schema without legacy path mode or variable expansion.
- Stage declared native artifacts after emit, retaining package metadata and registration entry points.
- Resolve generated registration/proxy modules from the application output and pass the application path before runtime flags.
- Extract development-side manifest tests without depending on the pending builder packaging implementation.

## Out of scope
Application packaging, electron-builder integration, template changes, browser demo and runtime download defaults remain in #234. This PR does not establish the complete packaged-app workflow. Existing PR source branches and alpha tags are unchanged.

## Validation
- Immutable dependency installation with build scripts skipped passed.
- Dev-plugin TypeScript build and all 24 tests passed.
- All 14 CEF tests passed, including prerequisite tests.
- git diff --check passed.
- Native CEF compilation, real webview rendering and DMG acceptance have not been rerun for this extraction.