### PR TITLE
[BugFix][AutoLink] Package native libraries in desktop applications

### DIFF
--- a/src/.changeset/autolink-app-packaging.md
+++ b/src/.changeset/autolink-app-packaging.md
@@ -1,0 +1,10 @@
+---
+"@lynx-js/lynxtron-builder": patch
+"create-lynxtron": patch
+---
+
+Package staged AutoLink native libraries without application-specific native
+layout configuration. Place declared macOS Frameworks and helper app bundles
+in Contents/Frameworks and keep native runtime files outside ASAR. Remove the
+template's duplicate application copy and load its Lynx bundle relative to the
+packaged main entry.

--- a/src/packages/cef-webview/README.md
+++ b/src/packages/cef-webview/README.md
@@ -24,6 +24,10 @@ and selects its addon from the literal target paths in `lynx.lib.json`.
 The manifest also declares the CEF Framework/helper bundles on macOS and the
 DLLs, subprocess and resource files on Windows for development staging.
 
+When packaging the app, lynxtron-builder places the declared macOS Framework
+and helper app bundles in `Contents/Frameworks` before signing. Windows native
+runtime files remain adjacent to the addon outside ASAR.
+
 ```ts
 import cefWebview from '@lynx-js/cef-webview/lynxtron';
 

--- a/src/packages/lynxtron-builder/README.md
+++ b/src/packages/lynxtron-builder/README.md
@@ -18,3 +18,23 @@ lynxtron-builder --lynxtron-runtime=devtool --mac
 ```
 
 Selection precedence is command line, `LYNXTRON_RUNTIME_VARIANT`, `electron-builder.yml`, then the `release` default. An explicitly configured `electronDownload` remains authoritative.
+
+## AutoLink native packages
+
+`pluginLynxtron()` stages matching native packages under
+`.lynxtron/native`. The builder includes that directory in the final app and
+keeps it outside ASAR so native addons and adjacent runtime files remain
+loadable.
+
+Every `lynx.lib.json` target must use literal package-relative artifact paths
+and standard `os` (`darwin`, `win32`, `linux`) and `arch` (`arm64`, `x64`, `ia32`)
+names. Variables, globs, and aliases are rejected. The builder selects the
+packaging target from the original staged manifest; it does not expand or
+rewrite that manifest.
+
+For macOS targets, Frameworks and nested applications declared by the selected
+`platforms.lynxtron.targets` record are copied into `Contents/Frameworks` with
+their symbolic links preserved. Nested applications use `appBundles` and are
+included before electron-builder signs the outer application. For Windows
+targets, declared `files` stay under `app.asar.unpacked`, including the selected
+`.node` addon, DLLs, resource packs, and locales.

--- a/src/packages/lynxtron-builder/autolink-packaging.js
+++ b/src/packages/lynxtron-builder/autolink-packaging.js
@@ -1,0 +1,356 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const AUTOLINK_NATIVE_DIR = path.join('.lynxtron', 'native');
+
+function prepareAutoLinkPackaging({ config, projectRoot, platform, arch }) {
+  const appDirectory = resolveAppDirectory(config, projectRoot);
+  const libraries = discoverAutoLinkLibraries({
+    appDirectory,
+    platform,
+    arch,
+  });
+
+  if (libraries.length === 0) {
+    return { config, libraries, appDirectory };
+  }
+
+  if (config.files === undefined) {
+    config.files = ['**/*'];
+  }
+  appendUnique(
+    config,
+    'files',
+    toPosix(path.join(AUTOLINK_NATIVE_DIR, '**/*'))
+  );
+  if (config.asar !== false) {
+    appendUnique(
+      config,
+      'asarUnpack',
+      toPosix(path.join(AUTOLINK_NATIVE_DIR, '**/*'))
+    );
+  }
+
+  for (const library of libraries) {
+    const dependencyPath = toPosix(
+      path.join('node_modules', ...library.packageName.split('/'))
+    );
+    appendUnique(config, 'files', `!${dependencyPath}`);
+    appendUnique(config, 'files', `!${dependencyPath}/**/*`);
+  }
+
+  if (platform === 'darwin') {
+    for (const library of libraries) {
+      for (const framework of library.frameworks) {
+        const relativeFrameworkPath = toPosix(
+          path.relative(appDirectory, framework.absolutePath)
+        );
+        appendUnique(config, 'files', `!${relativeFrameworkPath}`);
+        appendUnique(config, 'files', `!${relativeFrameworkPath}/**/*`);
+        appendUniqueFileSet(config, 'extraFiles', {
+          from: framework.absolutePath,
+          to: toPosix(path.join('Frameworks', path.basename(framework.path))),
+          filter: ['**/*'],
+        });
+      }
+      for (const appBundle of library.appBundles) {
+        const relativeAppBundlePath = toPosix(
+          path.relative(appDirectory, appBundle.absolutePath)
+        );
+        appendUnique(config, 'files', `!${relativeAppBundlePath}`);
+        appendUnique(config, 'files', `!${relativeAppBundlePath}/**/*`);
+        appendUniqueFileSet(config, 'extraFiles', {
+          from: appBundle.absolutePath,
+          to: toPosix(path.join('Frameworks', path.basename(appBundle.path))),
+          filter: ['**/*'],
+        });
+      }
+    }
+  }
+
+  return { config, libraries, appDirectory };
+}
+
+function discoverAutoLinkLibraries({ appDirectory, platform, arch }) {
+  const nodeModulesDirectory = path.join(
+    appDirectory,
+    AUTOLINK_NATIVE_DIR,
+    'node_modules'
+  );
+  if (!fs.existsSync(nodeModulesDirectory)) {
+    return [];
+  }
+
+  const libraries = [];
+  for (const packageRoot of listPackageRoots(nodeModulesDirectory)) {
+    const packageJsonPath = path.join(packageRoot, 'package.json');
+    const manifestPath = path.join(packageRoot, 'lynx.lib.json');
+    if (!fs.existsSync(packageJsonPath) || !fs.existsSync(manifestPath)) {
+      continue;
+    }
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    if (typeof packageJson.name !== 'string' || packageJson.name.length === 0) {
+      throw new Error(`${packageJsonPath} has no package name`);
+    }
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const lynxtron = manifest?.platforms?.lynxtron;
+    if (!lynxtron || typeof lynxtron !== 'object') {
+      continue;
+    }
+
+    for (const target of Array.isArray(lynxtron.targets)
+      ? lynxtron.targets
+      : []) {
+      if (
+        !['darwin', 'win32', 'linux'].includes(target?.os) ||
+        !['arm64', 'x64', 'ia32'].includes(target?.arch)
+      ) {
+        throw new Error(
+          `${manifestPath} requires standard os/arch names, got ${target?.os}/${target?.arch}`
+        );
+      }
+      for (const field of ['files', 'frameworks', 'appBundles']) {
+        validateFixedArtifactPaths(target[field], manifestPath, field);
+      }
+    }
+    const targets = Array.isArray(lynxtron.targets)
+      ? lynxtron.targets.filter(
+          (entry) => entry?.os === platform && entry?.arch === arch
+        )
+      : [];
+    if (targets.length === 0) {
+      throw new Error(
+        `${manifestPath} has no Lynxtron target for ${platform}/${arch}`
+      );
+    }
+    if (targets.length > 1) {
+      throw new Error(
+        `${manifestPath} has duplicate Lynxtron targets for ${platform}/${arch}`
+      );
+    }
+    const target = targets[0];
+
+    if ('binary' in target || 'binaries' in target || 'resources' in target) {
+      throw new Error(
+        `${manifestPath} does not support binary, binaries, or resources in Lynxtron targets; use files`
+      );
+    }
+
+    const files = resolveArtifactPaths({
+      paths: target.files,
+      packageRoot,
+      platform,
+      arch,
+      field: 'files',
+      manifestPath,
+    });
+    const frameworks = resolveArtifactPaths({
+      paths: target.frameworks,
+      packageRoot,
+      platform,
+      arch,
+      field: 'frameworks',
+      manifestPath,
+    });
+    const appBundles = resolveArtifactPaths({
+      paths: target.appBundles,
+      packageRoot,
+      platform,
+      arch,
+      field: 'appBundles',
+      manifestPath,
+    });
+
+    if (frameworks.length > 0 && platform !== 'darwin') {
+      throw new Error(
+        `${manifestPath} only supports frameworks for darwin targets`
+      );
+    }
+    for (const framework of frameworks) {
+      if (!framework.path.endsWith('.framework')) {
+        throw new Error(
+          `${manifestPath} frameworks path must end in .framework: ${framework.path}`
+        );
+      }
+    }
+
+    if (
+      files.length === 0 &&
+      frameworks.length === 0 &&
+      appBundles.length === 0
+    ) {
+      throw new Error(
+        `${manifestPath} has no Lynxtron artifacts for ${platform}/${arch}`
+      );
+    }
+
+    if (appBundles.length > 0 && platform !== 'darwin') {
+      throw new Error(
+        `${manifestPath} only supports appBundles for darwin targets`
+      );
+    }
+    for (const appBundle of appBundles) {
+      if (!appBundle.path.endsWith('.app')) {
+        throw new Error(
+          `${manifestPath} appBundles path must end in .app: ${appBundle.path}`
+        );
+      }
+    }
+
+    libraries.push({
+      packageName: packageJson.name,
+      packageRoot,
+      manifestPath,
+      files,
+      frameworks,
+      appBundles,
+    });
+  }
+  return libraries;
+}
+
+function listPackageRoots(nodeModulesDirectory) {
+  const roots = [];
+  for (const entry of fs.readdirSync(nodeModulesDirectory, {
+    withFileTypes: true,
+  })) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue;
+    }
+    const entryPath = path.join(nodeModulesDirectory, entry.name);
+    if (!entry.name.startsWith('@')) {
+      roots.push(entryPath);
+      continue;
+    }
+    for (const scopedEntry of fs.readdirSync(entryPath, {
+      withFileTypes: true,
+    })) {
+      if (scopedEntry.isDirectory() || scopedEntry.isSymbolicLink()) {
+        roots.push(path.join(entryPath, scopedEntry.name));
+      }
+    }
+  }
+  return roots;
+}
+
+function validateFixedArtifactPaths(paths, manifestPath, field) {
+  if (paths === undefined) return;
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error(`${manifestPath} has an invalid ${field} declaration`);
+  }
+  for (const value of paths) {
+    const relativePath =
+      typeof value === 'string' ? value.replaceAll('\\', '/') : '';
+    if (
+      !relativePath ||
+      relativePath.includes('${') ||
+      /[*?\[\]{}]/.test(relativePath) ||
+      path.posix.isAbsolute(relativePath) ||
+      /^[A-Za-z]:\//.test(relativePath) ||
+      relativePath.split('/').includes('..')
+    ) {
+      throw new Error(
+        `${manifestPath} requires fixed package-relative artifact paths in ${field}, got ${String(
+          value
+        )}`
+      );
+    }
+  }
+}
+
+function resolveArtifactPaths({
+  paths,
+  packageRoot,
+  platform,
+  arch,
+  field,
+  manifestPath,
+}) {
+  if (paths === undefined) {
+    return [];
+  }
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error(`${manifestPath} has an invalid ${field} declaration`);
+  }
+
+  return paths.map((artifactPath) => {
+    if (typeof artifactPath !== 'string' || artifactPath.length === 0) {
+      throw new Error(`${manifestPath} has an invalid ${field} path`);
+    }
+    const absolutePath = path.resolve(packageRoot, artifactPath);
+    if (!isInside(packageRoot, absolutePath)) {
+      throw new Error(
+        `${manifestPath} ${field} path escapes its package: ${artifactPath}`
+      );
+    }
+    if (!fs.existsSync(absolutePath)) {
+      throw new Error(
+        `${manifestPath} ${field} path does not exist for ${platform}/${arch}: ${artifactPath}`
+      );
+    }
+    return { path: artifactPath, absolutePath };
+  });
+}
+
+function resolveAppDirectory(config, projectRoot) {
+  const configuredAppDirectory = config.directories?.app;
+  return configuredAppDirectory
+    ? path.resolve(projectRoot, configuredAppDirectory)
+    : projectRoot;
+}
+
+function appendUnique(config, field, value) {
+  const existing = config[field];
+  const values =
+    existing === undefined
+      ? []
+      : Array.isArray(existing)
+      ? existing
+      : [existing];
+  if (!values.some((item) => item === value)) {
+    values.push(value);
+  }
+  config[field] = values;
+}
+
+function appendUniqueFileSet(config, field, value) {
+  const existing = config[field];
+  const values =
+    existing === undefined
+      ? []
+      : Array.isArray(existing)
+      ? existing
+      : [existing];
+  if (
+    !values.some(
+      (item) =>
+        item &&
+        typeof item === 'object' &&
+        item.from === value.from &&
+        item.to === value.to
+    )
+  ) {
+    values.push(value);
+  }
+  config[field] = values;
+}
+
+function isInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !path.isAbsolute(relative))
+  );
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+module.exports = {
+  AUTOLINK_NATIVE_DIR,
+  discoverAutoLinkLibraries,
+  prepareAutoLinkPackaging,
+  resolveAppDirectory,
+};

--- a/src/packages/lynxtron-builder/cli.js
+++ b/src/packages/lynxtron-builder/cli.js
@@ -12,6 +12,7 @@ const {
   resolveCliArchitectures,
   resolveTargetPlatform,
 } = require('./runtime-config.js');
+const { prepareAutoLinkPackaging } = require('./autolink-packaging.js');
 
 const projectRoot = process.cwd();
 const configPath = path.join(projectRoot, 'electron-builder.yml');
@@ -96,6 +97,13 @@ function runBuild(arch, rawArgs, { filterTargets = false } = {}) {
         filterTargets,
       });
     }
+
+    prepareAutoLinkPackaging({
+      config,
+      projectRoot,
+      platform: prepared.platform,
+      arch: prepared.arch,
+    });
 
     fs.writeFileSync(tempConfigPath, JSON.stringify(config, null, 2));
 

--- a/src/packages/lynxtron-builder/package.json
+++ b/src/packages/lynxtron-builder/package.json
@@ -11,6 +11,7 @@
     "cli.js",
     "patch.js",
     "runtime-config.js",
+    "autolink-packaging.js",
     "README.md",
     "package.json"
   ],

--- a/src/packages/lynxtron-builder/test/autolink-packaging.test.js
+++ b/src/packages/lynxtron-builder/test/autolink-packaging.test.js
@@ -1,0 +1,356 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  validateConfiguration,
+} = require('app-builder-lib/out/util/config/config.js');
+
+const { prepareAutoLinkPackaging } = require('../autolink-packaging.js');
+
+const tempDirectories = [];
+
+test.afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('packages macOS AutoLink addons, Frameworks, and app bundles', async () => {
+  const fixture = createFixture();
+  const config = {
+    directories: { app: 'dist/desktop' },
+    files: ['main.js'],
+    asar: true,
+  };
+
+  const result = prepareAutoLinkPackaging({
+    config,
+    projectRoot: fixture.projectRoot,
+    platform: 'darwin',
+    arch: 'arm64',
+  });
+
+  assert.equal(result.libraries.length, 1);
+  assert.ok(config.files.includes('.lynxtron/native/**/*'));
+  assert.ok(config.files.includes('!node_modules/@lynx-js/cef-webview'));
+  assert.ok(
+    config.files.includes('!node_modules/@lynx-js/cef-webview/**/*')
+  );
+  assert.ok(
+    config.files.includes(
+      '!.lynxtron/native/node_modules/@lynx-js/cef-webview/dist/darwin/arm64/frameworks/Chromium Embedded Framework.framework/**/*'
+    )
+  );
+  assert.ok(
+    config.files.includes(
+      '!.lynxtron/native/node_modules/@lynx-js/cef-webview/dist/darwin/arm64/frameworks/LynxtronWebview Helper.app/**/*'
+    )
+  );
+  assert.ok(config.asarUnpack.includes('.lynxtron/native/**/*'));
+  assert.deepEqual(config.extraFiles, [
+    {
+      from: fixture.frameworksPath,
+      to: 'Frameworks/Chromium Embedded Framework.framework',
+      filter: ['**/*'],
+    },
+    {
+      from: fixture.appBundlePath,
+      to: 'Frameworks/LynxtronWebview Helper.app',
+      filter: ['**/*'],
+    },
+  ]);
+
+  const debugLogger = { isEnabled: false, add() {} };
+  await assert.doesNotReject(validateConfiguration(config, debugLogger));
+});
+
+test('packages Windows AutoLink addon and adjacent CEF runtime files unpacked', () => {
+  const fixture = createFixture();
+  const config = {
+    directories: { app: 'dist/desktop' },
+    files: ['main.js'],
+    asar: true,
+  };
+
+  const result = prepareAutoLinkPackaging({
+    config,
+    projectRoot: fixture.projectRoot,
+    platform: 'win32',
+    arch: 'x64',
+  });
+
+  assert.equal(result.libraries.length, 1);
+  assert.equal(
+    result.libraries[0].files[0].path,
+    'dist/win32/x64/cef_extension.node'
+  );
+  assert.equal(result.libraries[0].files[1].path, 'dist/win32/x64/libcef.dll');
+  assert.ok(config.files.includes('.lynxtron/native/**/*'));
+  assert.ok(config.files.includes('!node_modules/@lynx-js/cef-webview'));
+  assert.ok(
+    config.files.includes('!node_modules/@lynx-js/cef-webview/**/*')
+  );
+  assert.ok(config.asarUnpack.includes('.lynxtron/native/**/*'));
+  assert.equal(config.extraFiles, undefined);
+  assert.ok(
+    fs.existsSync(
+      path.join(
+        result.libraries[0].packageRoot,
+        'dist',
+        'win32',
+        'x64',
+        'libcef.dll'
+      )
+    )
+  );
+});
+
+test('preserves electron-builder default app files when files is omitted', () => {
+  const fixture = createFixture();
+  const config = {
+    directories: { app: 'dist/desktop' },
+    asar: true,
+  };
+
+  prepareAutoLinkPackaging({
+    config,
+    projectRoot: fixture.projectRoot,
+    platform: 'win32',
+    arch: 'x64',
+  });
+
+  assert.deepEqual(config.files, [
+    '**/*',
+    '.lynxtron/native/**/*',
+    '!node_modules/@lynx-js/cef-webview',
+    '!node_modules/@lynx-js/cef-webview/**/*',
+  ]);
+});
+
+test('fails before packaging when the target architecture artifact is absent', () => {
+  const fixture = createFixture();
+  fs.rmSync(
+    path.join(
+      fixture.packageRoot,
+      'dist',
+      'darwin',
+      'x64',
+      'cef_extension.node'
+    )
+  );
+
+  assert.throws(
+    () =>
+      prepareAutoLinkPackaging({
+        config: { directories: { app: 'dist/desktop' } },
+        projectRoot: fixture.projectRoot,
+        platform: 'darwin',
+        arch: 'x64',
+      }),
+    /does not exist for darwin\/x64/
+  );
+});
+
+test('rejects legacy Lynxtron artifact categories', () => {
+  const fixture = createFixture();
+  const manifestPath = path.join(fixture.packageRoot, 'lynx.lib.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const target = manifest.platforms.lynxtron.targets.find(
+    ({ os, arch }) => os === 'win32' && arch === 'x64'
+  );
+  target.binaries = target.files;
+  delete target.files;
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+  assert.throws(
+    () =>
+      prepareAutoLinkPackaging({
+        config: { directories: { app: 'dist/desktop' } },
+        projectRoot: fixture.projectRoot,
+        platform: 'win32',
+        arch: 'x64',
+      }),
+    /does not support binary, binaries, or resources.*use files/
+  );
+});
+
+test('rejects app bundles for non-macOS targets', () => {
+  const fixture = createFixture();
+  const manifestPath = path.join(fixture.packageRoot, 'lynx.lib.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const target = manifest.platforms.lynxtron.targets.find(
+    ({ os, arch }) => os === 'win32' && arch === 'x64'
+  );
+  target.appBundles = [
+    'dist/darwin/arm64/frameworks/LynxtronWebview Helper.app',
+  ];
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+  assert.throws(
+    () =>
+      prepareAutoLinkPackaging({
+        config: { directories: { app: 'dist/desktop' } },
+        projectRoot: fixture.projectRoot,
+        platform: 'win32',
+        arch: 'x64',
+      }),
+    /only supports appBundles for darwin targets/
+  );
+});
+
+test('rejects Framework bundles for non-macOS targets', () => {
+  const fixture = createFixture();
+  const manifestPath = path.join(fixture.packageRoot, 'lynx.lib.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const target = manifest.platforms.lynxtron.targets.find(
+    ({ os, arch }) => os === 'win32' && arch === 'x64'
+  );
+  target.frameworks = [
+    'dist/darwin/arm64/frameworks/Chromium Embedded Framework.framework',
+  ];
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+  assert.throws(
+    () =>
+      prepareAutoLinkPackaging({
+        config: { directories: { app: 'dist/desktop' } },
+        projectRoot: fixture.projectRoot,
+        platform: 'win32',
+        arch: 'x64',
+      }),
+    /only supports frameworks for darwin targets/
+  );
+});
+
+function createFixture() {
+  const projectRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'lynxtron-builder-autolink-')
+  );
+  tempDirectories.push(projectRoot);
+  const packageRoot = path.join(
+    projectRoot,
+    'dist',
+    'desktop',
+    '.lynxtron',
+    'native',
+    'node_modules',
+    '@lynx-js',
+    'cef-webview'
+  );
+  const frameworksPath = path.join(
+    packageRoot,
+    'dist',
+    'darwin',
+    'arm64',
+    'frameworks'
+  );
+  fs.mkdirSync(frameworksPath, { recursive: true });
+  const frameworkPath = path.join(
+    frameworksPath,
+    'Chromium Embedded Framework.framework'
+  );
+  const appBundlePath = path.join(
+    frameworksPath,
+    'LynxtronWebview Helper.app'
+  );
+  fs.mkdirSync(frameworkPath, { recursive: true });
+  fs.mkdirSync(path.join(appBundlePath, 'Contents', 'MacOS'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(packageRoot, 'dist', 'darwin', 'x64'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(packageRoot, 'dist', 'win32', 'x64'), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(packageRoot, 'package.json'),
+    JSON.stringify({ name: '@lynx-js/cef-webview' })
+  );
+  fs.writeFileSync(path.join(packageRoot, 'index.cjs'), 'module.exports = {};');
+  fs.writeFileSync(
+    path.join(packageRoot, 'dist', 'darwin', 'arm64', 'cef_extension.node'),
+    'arm64'
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, 'dist', 'darwin', 'x64', 'cef_extension.node'),
+    'x64'
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, 'dist', 'win32', 'x64', 'cef_extension.node'),
+    'win32'
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, 'dist', 'win32', 'x64', 'libcef.dll'),
+    'cef'
+  );
+  fs.writeFileSync(
+    path.join(frameworkPath, 'Chromium Embedded Framework'),
+    'framework'
+  );
+  fs.writeFileSync(
+    path.join(
+      appBundlePath,
+      'Contents',
+      'MacOS',
+      'LynxtronWebview Helper'
+    ),
+    'helper'
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, 'lynx.lib.json'),
+    JSON.stringify({
+      platforms: {
+        lynxtron: {
+          targets: [
+            {
+              os: 'darwin',
+              arch: 'arm64',
+              files: ['dist/darwin/arm64/cef_extension.node'],
+              frameworks: [
+                'dist/darwin/arm64/frameworks/Chromium Embedded Framework.framework',
+              ],
+              appBundles: [
+                'dist/darwin/arm64/frameworks/LynxtronWebview Helper.app',
+              ],
+            },
+            {
+              os: 'darwin',
+              arch: 'x64',
+              files: ['dist/darwin/x64/cef_extension.node'],
+              frameworks: [
+                'dist/darwin/x64/Chromium Embedded Framework.framework',
+              ],
+            },
+            {
+              os: 'win32',
+              arch: 'x64',
+              files: [
+                'dist/win32/x64/cef_extension.node',
+                'dist/win32/x64/libcef.dll',
+              ],
+            },
+          ],
+        },
+      },
+    })
+  );
+  fs.mkdirSync(
+    path.join(
+      packageRoot,
+      'dist',
+      'darwin',
+      'x64',
+      'Chromium Embedded Framework.framework'
+    )
+  );
+
+  return {
+    projectRoot,
+    packageRoot,
+    frameworksPath: frameworkPath,
+    appBundlePath,
+  };
+}

--- a/src/packages/lynxtron-builder/test/template-packaging.test.js
+++ b/src/packages/lynxtron-builder/test/template-packaging.test.js
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const yaml = require('js-yaml');
+
+for (const name of ['lynxtron-shell-demo']) {
+  test(`${name} packages the application directory only once`, () => {
+    const packageRoot = path.resolve(__dirname, '../..', name);
+    const config = yaml.load(
+      fs.readFileSync(path.join(packageRoot, 'electron-builder.yml'), 'utf8')
+    );
+    assert.equal(config.directories.app, 'dist/desktop');
+    // App files are packaged through directories.app/files. Copying the same
+    // tree through extraResources duplicates all staged native payloads.
+    for (const copy of config.extraResources || []) {
+      assert.notEqual(
+        path.resolve(packageRoot, copy.from),
+        path.resolve(packageRoot, config.directories.app)
+      );
+    }
+    assert.deepEqual(config.extraResources, [
+      { from: 'src/assets', to: 'assets' },
+    ]);
+  });
+}
+
+test('create-lynxtron generates its template from the deduplicated shell demo', () => {
+  const generator = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      '../../create-lynxtron/scripts/generate-template.js'
+    ),
+    'utf8'
+  );
+  assert.match(
+    generator,
+    /const srcDir = path.resolve\(pkgDir, '..', 'lynxtron-shell-demo'\)/
+  );
+});

--- a/src/packages/lynxtron-dev-plugins/test/manifest-contract.test.js
+++ b/src/packages/lynxtron-dev-plugins/test/manifest-contract.test.js
@@ -3,8 +3,14 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { createRequire } from 'node:module';
 import { resolveLynxtronAutoLinks } from '../dist/autolink.js';
 import { applyLynxtronAutoLink } from '../dist/autolink-rspack.js';
+
+const require = createRequire(import.meta.url);
+const {
+  prepareAutoLinkPackaging,
+} = require('../../lynxtron-builder/autolink-packaging.js');
 
 function fixture(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lynxtron-manifest-'));
@@ -55,7 +61,7 @@ for (const [platform, arch] of [
   ['darwin', 'arm64'],
   ['win32', 'x64'],
 ]) {
-  test(`fixed manifest survives resolve and stage unchanged: ${platform}/${arch}`, (t) => {
+  test(`fixed manifest survives resolve, stage and pack unchanged: ${platform}/${arch}`, (t) => {
     const f = fixture(t);
     f.write();
     const original = fs.readFileSync(path.join(f.pkg, 'lynx.lib.json'), 'utf8');
@@ -94,6 +100,13 @@ for (const [platform, arch] of [
       ),
       original
     );
+    const result = prepareAutoLinkPackaging({
+      config: { directories: { app: 'output' } },
+      projectRoot: f.root,
+      platform,
+      arch,
+    });
+    assert.equal(result.libraries.length, 1);
   });
 }
 
@@ -152,7 +165,7 @@ const invalid = [
 ];
 
 for (const [name, mutate, error] of invalid) {
-  test(`dev-plugin rejects ${name}, even in an unselected target`, (t) => {
+  test(`both consumers reject ${name}, even in an unselected target`, (t) => {
     const f = fixture(t);
     mutate(f.manifest.platforms.lynxtron.targets[1]);
     f.write();
@@ -160,6 +173,23 @@ for (const [name, mutate, error] of invalid) {
       () =>
         resolveLynxtronAutoLinks({
           root: f.root,
+          platform: 'darwin',
+          arch: 'arm64',
+        }),
+      error
+    );
+    // Model a package already present in staging, bypassing the dev-plugin.
+    const staged = path.join(
+      f.root,
+      'output/.lynxtron/native/node_modules/fixture'
+    );
+    fs.mkdirSync(path.dirname(staged), { recursive: true });
+    fs.cpSync(f.pkg, staged, { recursive: true });
+    assert.throws(
+      () =>
+        prepareAutoLinkPackaging({
+          config: { directories: { app: 'output' } },
+          projectRoot: f.root,
           platform: 'darwin',
           arch: 'arm64',
         }),

--- a/src/packages/lynxtron-shell-demo/electron-builder.yml
+++ b/src/packages/lynxtron-shell-demo/electron-builder.yml
@@ -21,8 +21,6 @@ npmRebuild: false
 extraResources:
   - from: src/assets
     to: assets
-  - from: dist/desktop
-    to: resources/app
 icon: lynxtron.png
 electronBranding:
   projectName: lynxtron

--- a/src/packages/lynxtron-shell-demo/src/main/desktop/vendorPaths.ts
+++ b/src/packages/lynxtron-shell-demo/src/main/desktop/vendorPaths.ts
@@ -4,8 +4,4 @@
 
 import path from 'path';
 
-const bundleFileName = 'main.lynx.bundle';
-
-export const LYNX_BUNDLE_PATH = __dirname.includes('app.asar')
-  ? path.join(process.resourcesPath, 'resources', 'app', bundleFileName)
-  : path.join(__dirname, bundleFileName);
+export const LYNX_BUNDLE_PATH = path.join(__dirname, 'main.lynx.bundle');


### PR DESCRIPTION
## Scope and dependency
Fourth extraction from #234: AutoLink application packaging and template deduplication.
#254 has merged. Rebased onto origin/main at d37c96e; this PR targets main and contains only the packaging commit.

## Changes
- Discover staged AutoLink libraries and validate/select literal target artifacts.
- Keep native addon/runtime files outside ASAR; on macOS copy declared frameworks and helper app bundles to Contents/Frameworks through electron-builder extraFiles.
- Exclude duplicate native package copies and preserve default application file selection.
- Remove the template's duplicate dist/desktop extraResources copy and resolve its Lynx bundle relative to the main entry.
- Include the packaging helper in the builder npm package.
- Extend the existing manifest-contract tests to cover resolve, stage and pack together; browser demo and generic runtime download changes remain in #234.

## Validation
- After rebasing onto main: 59 builder and manifest-contract tests passed; range-diff confirms the packaging patch is unchanged.
- Immutable dependency installation with lifecycle builds skipped passed.
- Ran the builder's existing postinstall patch step before its full test suite. The initial unpatched install caused two existing cache tests to fail; both passed after the normal patch step, without source changes.
- All 39 builder tests passed.
- Dev-plugin TypeScript build and all 24 tests passed.
- create-lynxtron build passed; generated template verified to package the app once and use the main-relative Lynx bundle path.
- git diff --check passed.
- Tests cover fixtures/configuration, including electron-builder configuration validation. Full DMG creation, signing and native runtime acceptance have not been rerun for this extraction.

Existing PR source branches and alpha tags are unchanged.