### PR TITLE
[BugFix][Runtime] Download missing runtimes from Lynxtron releases

### DIFF
--- a/src/.changeset/runtime-download-default.md
+++ b/src/.changeset/runtime-download-default.md
@@ -1,0 +1,7 @@
+---
+"@lynx-js/lynxtron": patch
+"@lynx-js/lynxtron-builder": patch
+---
+
+Default missing runtime downloads to the matching versioned Lynxtron GitHub
+release while preserving explicit download configuration.

--- a/src/packages/lynxtron-builder/README.md
+++ b/src/packages/lynxtron-builder/README.md
@@ -17,4 +17,4 @@ You can also override the variant for one command:
 lynxtron-builder --lynxtron-runtime=devtool --mac
 ```
 
-Selection precedence is command line, `LYNXTRON_RUNTIME_VARIANT`, `electron-builder.yml`, then the `release` default. An explicitly configured `electronDownload` remains authoritative.
+Selection precedence is command line, `LYNXTRON_RUNTIME_VARIANT`, `electron-builder.yml`, then the `release` default. By default, the builder downloads the matching versioned runtime from the Lynxtron GitHub release. An explicitly configured `electronDownload` remains authoritative.

--- a/src/packages/lynxtron-builder/runtime-config.js
+++ b/src/packages/lynxtron-builder/runtime-config.js
@@ -205,7 +205,7 @@ function prepareRuntimeConfig({
     }
     config.electronDownload = {
       version: effectiveVersion,
-      mirror: '',
+      mirror: runtimeArtifacts.DEFAULT_RUNTIME_DOWNLOAD_MIRROR,
       customDir: `v${effectiveVersion}`,
       customFilename: runtimeArtifacts.getRuntimeArtifactFilename({
         version: effectiveVersion,

--- a/src/packages/lynxtron-builder/test/runtime-config.test.js
+++ b/src/packages/lynxtron-builder/test/runtime-config.test.js
@@ -28,6 +28,10 @@ function prepare({ config = {}, args = [], env = {}, arch } = {}) {
 test('builder defaults to the release runtime', () => {
   const result = prepare();
   assert.equal(result.variant, 'release');
+  assert.equal(
+    result.config.electronDownload.mirror,
+    'https://github.com/lynx-family/lynxtron/releases/download/'
+  );
   assert.equal(result.config.electronDownload.customFilename, 'lynxtron-v1.2.3-darwin-arm64.zip');
 });
 

--- a/src/packages/lynxtron/install.js
+++ b/src/packages/lynxtron/install.js
@@ -1,11 +1,5 @@
 import { getPostinstallRuntimeOptions } from './install-policy.js';
 import { ensureRuntime } from './runtime-manager.js';
-import { BASE_URL } from './utils/env-config.js';
 
 const options = getPostinstallRuntimeOptions();
-const { customUrl } = options;
-if (!customUrl && !BASE_URL) {
-  console.log('Lynxtron base URL is empty; skipping runtime download');
-} else {
-  await ensureRuntime(options);
-}
+await ensureRuntime(options);

--- a/src/packages/lynxtron/runtime-artifacts.cjs
+++ b/src/packages/lynxtron/runtime-artifacts.cjs
@@ -1,4 +1,6 @@
 const VALID_RUNTIME_VARIANTS = Object.freeze(['release', 'devtool']);
+const DEFAULT_RUNTIME_DOWNLOAD_MIRROR =
+  'https://github.com/lynx-family/lynxtron/releases/download/';
 
 function normalizeRuntimeVariant(value, fallback = 'release') {
   const variant = value == null ? fallback : value;
@@ -63,6 +65,7 @@ function resolveRuntimeVariant({
 }
 
 module.exports = {
+  DEFAULT_RUNTIME_DOWNLOAD_MIRROR,
   VALID_RUNTIME_VARIANTS,
   getRuntimeArtifactFilename,
   normalizeRuntimeVariant,

--- a/src/packages/lynxtron/runtime-artifacts.test.js
+++ b/src/packages/lynxtron/runtime-artifacts.test.js
@@ -4,11 +4,19 @@ import assert from 'node:assert/strict';
 import runtimeArtifacts from './runtime-artifacts.cjs';
 
 const {
+  DEFAULT_RUNTIME_DOWNLOAD_MIRROR,
   getRuntimeArtifactFilename,
   normalizeRuntimeVariant,
   parseRuntimeArguments,
   resolveRuntimeVariant,
 } = runtimeArtifacts;
+
+test('runtime downloads use the Lynxtron GitHub releases', () => {
+  assert.equal(
+    DEFAULT_RUNTIME_DOWNLOAD_MIRROR,
+    'https://github.com/lynx-family/lynxtron/releases/download/'
+  );
+});
 
 test('release and DevTool runtimes share a version and differ only by filename suffix', () => {
   assert.equal(

--- a/src/packages/lynxtron/runtime-manager.js
+++ b/src/packages/lynxtron/runtime-manager.js
@@ -14,7 +14,11 @@ import {
   VERSION,
 } from './utils/env-config.js';
 
-const { getRuntimeArtifactFilename, normalizeRuntimeVariant } = runtimeArtifacts;
+const {
+  DEFAULT_RUNTIME_DOWNLOAD_MIRROR,
+  getRuntimeArtifactFilename,
+  normalizeRuntimeVariant,
+} = runtimeArtifacts;
 const { extract: extractZip } = zipLib;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -33,7 +37,7 @@ export function getRuntimeExecutablePath(variant, packageRoot = __dirname) {
 }
 
 export function getRuntimeDownloadUrl({
-  baseUrl = BASE_URL,
+  baseUrl = BASE_URL || DEFAULT_RUNTIME_DOWNLOAD_MIRROR,
   version = VERSION,
   platform = PLATFORM,
   arch = ARCH,

--- a/src/packages/lynxtron/runtime-manager.test.js
+++ b/src/packages/lynxtron/runtime-manager.test.js
@@ -74,7 +74,11 @@ test('local runtime directories isolate release and DevTool binaries', () => {
   assert.match(getRuntimeExecutablePath('devtool', packageRoot), /dist[\\/]devtool[\\/]/);
 });
 
-test('DevTool download URL uses the stable release tag and suffixed asset', () => {
+test('runtime download URLs use the stable release tag and variant filename', () => {
+  assert.equal(
+    getRuntimeDownloadUrl({ version: '2.0.0', platform: 'linux', arch: 'x64', variant: 'release' }),
+    'https://github.com/lynx-family/lynxtron/releases/download/v2.0.0/lynxtron-v2.0.0-linux-x64.zip'
+  );
   assert.equal(
     getRuntimeDownloadUrl({ baseUrl: 'https://downloads.example.test/', version: '2.0.0', platform: 'linux', arch: 'x64', variant: 'devtool' }),
     'https://downloads.example.test/v2.0.0/lynxtron-v2.0.0-linux-x64-devtool.zip'


### PR DESCRIPTION
## Scope
Sixth extraction from #234, independently based on main. No CEF build, AutoLink, browser demo or workspace changes.

## Changes
- Share the default Lynxtron GitHub release download root between runtime-manager and builder configuration.
- Resolve the matching version/platform/architecture/runtime variant when no download root is configured.
- Let npm postinstall use runtime-manager instead of silently skipping when BASE_URL is empty.
- Preserve explicit runtime URLs and electronDownload configuration.
- Add focused default-download assertions and a changeset.

The source-build skip-download support remains in #252; when integrating the PRs, preserve that explicit skip guard alongside this default-download behavior.

## Validation
- Immutable install with lifecycle builds skipped passed.
- All 25 runtime-artifact, runtime-manager and builder runtime-config tests passed, including override, archive and concurrent-install cases.
- git diff --check passed.
- Tests do not download a production runtime from GitHub or establish native runtime launch success.

9 files, +36/-12. Existing PR branches and alpha tags are unchanged.