### PR TITLE
[Infra] Prototype local Ninja input fingerprints

### DIFF
--- a/lynxtron_tools/NATIVE_FINGERPRINT.md
+++ b/lynxtron_tools/NATIVE_FINGERPRINT.md
@@ -45,3 +45,41 @@ Next decision: obtain a conservative cold-build dependency closure (for example,
 pinned dependency tree identities plus owned native input trees), or perform
 dependency discovery before permitting a cache hit. Do not claim that hashing
 the generated build graph alone establishes that closure.
+
+## Follow-up local findings
+
+The real fixture now demonstrates a concrete false hit: after building code
+using `__has_include("optional.h")` while that file is absent, creating the
+header leaves the warm-log fingerprint unchanged. Forced recompilation discovers
+it and the executable returns the new header's value. A second clean configured
+build directory is rejected because it lacks compiler dependency logs.
+
+## Bounded storage plan (not connected to Habitat yet)
+
+Reserve a dedicated `native-artifacts-v1` namespace, never evict Habitat's
+dependency downloads. Require explicit byte and entry-count limits for the entire
+native namespace, shared across all platform/architecture keys, not per key.
+The limits must be chosen within the actual Habitat allocation; no unlimited
+default or inferred allocation. Also reserve free disk space for the build.
+
+`native_cache_budget.py` is a pure admission planner, not a storage backend:
+
+- Evict least-recently-used entries until both byte and count limits permit the
+  incoming entry; reject a single oversized artifact without evicting others.
+- Evict before staging incoming bytes, so atomic-write temporary files do not
+  silently double the allowed storage footprint. Failed admission remains a
+  cache miss and must not fail an otherwise successful build.
+- Future filesystem integration must account for metadata and temporary files,
+  serialize writers with a namespace lock, validate namespace ownership and
+  symlinks, pin active readers, and clean abandoned temporary files.
+- Restoring a globally cached namespace also needs pruning against the current
+  budget. Local quotas alone do not bound remote snapshot retention: that needs
+  the actual backend's retention policy.
+
+Five budget tests cover LRU order, byte/count caps, oversized rejection, invalid
+budgets, and 100 successive admissions. They do not establish filesystem or
+concurrency correctness. Run all local tests with:
+
+```sh
+python3 -m unittest discover -s lynxtron_tools -p 'test_native_*.py'
+```

--- a/lynxtron_tools/NATIVE_FINGERPRINT.md
+++ b/lynxtron_tools/NATIVE_FINGERPRINT.md
@@ -1,7 +1,60 @@
 # Local native fingerprint experiment
 
-This is an experiment, not a CI cache implementation. No workflow, Habitat
-storage, release logic, or existing build entry is changed.
+This is an experiment, not a CI cache implementation. No workflow, release
+logic, or existing build entry is changed. Only the opt-in local runner below
+writes a dedicated native cache namespace.
+
+## Opt-in local storage follow-up
+
+`local_native_cache.py` now implements locked local artifact storage with byte
+and entry-count budgets, LRU eviction, SHA-256 verification, safe tar extraction,
+and a non-overwriting restore destination. It refuses to adopt an existing
+nonempty directory without its ownership marker. It does not upload anything or
+touch Habitat dependency entries. Writers prepare an archive in a temporary
+directory outside Habitat, limited to the same byte budget; peak temporary plus
+retained archive usage is therefore at most twice that budget (excluding build
+outputs and restore destinations).
+
+The unsafe Ninja-only digest is NOT used to authorize these local cache hits.
+The storage tests use `input_key`, a conservative recursive content snapshot of
+explicit input roots plus tool files and environment identity. Directory
+membership is hashed, covering newly appearing optional headers. The caller
+still owns input completeness; this is not a universal hermetic build system.
+
+Real Clang/Ninja mutation tests compare restored binaries with forced rebuilds
+byte-for-byte and execute both. They cover 24 hit/miss cases, including eight
+seeded native mutations followed by repeated hits. Removing an optional header
+hits a previous entry when it restores an identical input state. Further tests
+cover tools/generators, architecture/SDK identity, symlinks, corruption, missing
+metadata, parallel writers, quota enforcement and unsafe archive links.
+
+For an isolated full Lynxtron macOS checkout marked with
+`.native-cache-acceptance-checkout`, the single entry is:
+
+```sh
+bash lynxtron_tools/run_local_native_acceptance.sh /absolute/isolated-checkout
+```
+
+This prepares dependencies and runs the actual arm64 `lynxtron_app` target. It
+uses a deliberately broad input snapshot, verifies inputs did not change during
+compilation, then caches/restores the complete app and compares its inventory.
+Only this opt-in runner writes `~/.habitat_cache/native-artifacts-v1`, limited to
+2 GiB and two entries. It always builds for verification; it does not yet skip
+real Lynxtron compilation on a cache hit. Real-app acceptance is pending until
+the runner completes; fixture success is not a substitute.
+
+CEF webview is in scope as a separate component identity sharing the same total
+storage quota. On an isolated checkout containing #258's actual CEF build entry:
+
+```sh
+bash lynxtron_tools/run_local_native_acceptance.sh /absolute/cef-checkout cef-webview
+```
+
+The CEF path calls the component build script, then validates a cache round trip
+of the staged addon, Framework, helper apps and resources. The CEF build/dist
+directories are excluded from source fingerprints. Its directory-layout test
+uses fixture bytes and is explicitly not a real CEF compilation or page-rendering
+test. Actual CEF acceptance remains pending.
 
 Run the real CMake/Ninja experiment with:
 
@@ -54,13 +107,14 @@ header leaves the warm-log fingerprint unchanged. Forced recompilation discovers
 it and the executable returns the new header's value. A second clean configured
 build directory is rejected because it lacks compiler dependency logs.
 
-## Bounded storage plan (not connected to Habitat yet)
+## Bounded storage policy
 
 Reserve a dedicated `native-artifacts-v1` namespace, never evict Habitat's
 dependency downloads. Require explicit byte and entry-count limits for the entire
 native namespace, shared across all platform/architecture keys, not per key.
-The limits must be chosen within the actual Habitat allocation; no unlimited
-default or inferred allocation. Also reserve free disk space for the build.
+Production limits must be chosen within the actual Habitat allocation. The
+local acceptance explicitly chooses 2 GiB/two entries and reserves free space
+for compilation. This does not establish a remote backend quota.
 
 `native_cache_budget.py` is a pure admission planner, not a storage backend:
 
@@ -69,9 +123,11 @@ default or inferred allocation. Also reserve free disk space for the build.
 - Evict before staging incoming bytes, so atomic-write temporary files do not
   silently double the allowed storage footprint. Failed admission remains a
   cache miss and must not fail an otherwise successful build.
-- Future filesystem integration must account for metadata and temporary files,
-  serialize writers with a namespace lock, validate namespace ownership and
-  symlinks, pin active readers, and clean abandoned temporary files.
+- Local integration accounts for archive/metadata bytes, serializes readers and
+  writers with a namespace lock, and validates namespace ownership and symlinks.
+  A killed process can leave external staging files; automatic recovery of those
+  temporary directories is not implemented, so repeated interrupted runs still
+  require an external bounded temporary-directory lifecycle.
 - Restoring a globally cached namespace also needs pruning against the current
   budget. Local quotas alone do not bound remote snapshot retention: that needs
   the actual backend's retention policy.

--- a/lynxtron_tools/NATIVE_FINGERPRINT.md
+++ b/lynxtron_tools/NATIVE_FINGERPRINT.md
@@ -1,0 +1,47 @@
+# Local native fingerprint experiment
+
+This is an experiment, not a CI cache implementation. No workflow, Habitat
+storage, release logic, or existing build entry is changed.
+
+Run the real CMake/Ninja experiment with:
+
+```sh
+python3 -m unittest discover -s lynxtron_tools -p test_native_fingerprint.py
+```
+
+After a successful Ninja build, inspect a target with:
+
+```sh
+python3 lynxtron_tools/native_fingerprint.py \
+  --build-dir /absolute/build --target probe \
+  --tool /absolute/compiler --identity '<actual SDK/environment identity>'
+```
+
+The manifest records Ninja input content hashes, commands, explicit tool hashes,
+and the supplied environment identity. Generated outputs are excluded: their
+producer inputs and commands, rather than object-file contents, determine the
+fingerprint. All headers in the dependency log are included conservatively.
+
+Local acceptance covers repeatability, unrelated JavaScript changes, C source,
+header, compile-definition, and explicit SDK-identity changes using real builds.
+
+## Boundaries before cache integration
+
+- A configured graph alone does not supply all compiler-discovered headers.
+  Missing or stale dependency logs are rejected. Even a valid previous log may
+  miss newly selected conditional includes until the next build. This digest
+  must not yet authorize skipping compilation.
+- Absolute paths remain part of the identity; cross-workspace reuse is not
+  implemented. Input parsing is POSIX-only; Windows quoting is not validated.
+- SDK contents, compiler subprocesses, environment variables, configuration
+  generators and undeclared custom-command inputs are not discovered fully.
+  Explicit tool files and an environment label do not prove hermeticity.
+- Directory dependencies are recorded as directory identities, not recursively
+  hashed. Changes inside undeclared input directories are not covered.
+- No real Lynxtron/CEF build, cold-run reuse, Habitat upload/download, concurrent
+  writer handling, or trusted publishing-cache boundary is validated here.
+
+Next decision: obtain a conservative cold-build dependency closure (for example,
+pinned dependency tree identities plus owned native input trees), or perform
+dependency discovery before permitting a cache hit. Do not claim that hashing
+the generated build graph alone establishes that closure.

--- a/lynxtron_tools/local_native_cache.py
+++ b/lynxtron_tools/local_native_cache.py
@@ -1,0 +1,194 @@
+"""Opt-in local POSIX artifact cache. Never reads other Habitat entries."""
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import tarfile
+import tempfile
+
+from native_cache_budget import plan_admission
+
+
+def file_hash(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def input_key(roots, identity, excluded=(), progress=None):
+    """Conservative full-tree content key, including previously absent headers.
+
+    Only Git metadata is omitted. Callers must keep outputs outside input roots
+    and supply every external dependency/toolchain and relevant environment.
+    No cross-checkout reuse: absolute root identities are intentional.
+    """
+    records = []
+    visited = set()
+    excluded = {Path(p).resolve() for p in excluded}
+
+    def visit(path, label, ancestors):
+        if progress:
+            progress(path)
+        resolved = path.resolve(strict=True)
+        if any(resolved == p or p in resolved.parents for p in excluded):
+            return
+        if resolved in ancestors:
+            # Dependency trees (notably pnpm) can link back to an ancestor. Its
+            # directory contents are already being traversed; retain the edge.
+            records.append((label, "back-reference", str(resolved)))
+            return
+        if path.is_symlink():
+            records.append((label, "link", os.readlink(path)))
+        if resolved in visited:
+            records.append((label, "alias", str(resolved)))
+            return
+        visited.add(resolved)
+        if path.is_dir():
+            records.append((label, "directory"))
+            for child in sorted(path.iterdir()):
+                if child.name != ".git":
+                    visit(child, label + "/" + child.name, ancestors | {resolved})
+        elif path.is_file():
+            records.append((label, path.stat().st_mode & 0o777, file_hash(path)))
+        else:
+            raise ValueError(f"Unsupported input: {label}")
+
+    for root in sorted(roots, key=str):
+        path = Path(root).absolute()
+        visit(path, str(path), set())
+    data = json.dumps({"schema": 1, "inputs": records, "identity": identity},
+                      sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
+class LocalCache:
+    def __init__(self, root, max_bytes, max_entries):
+        self.root = Path(root).absolute()
+        self.max_bytes = max_bytes
+        self.max_entries = max_entries
+        plan_admission([], 0, max_bytes, max_entries)
+        if self.root.is_symlink():
+            raise ValueError("Cache root must not be a symlink")
+        self.root.mkdir(parents=True, exist_ok=True)
+        marker = self.root / ".native-cache-v1"
+        if not marker.exists():
+            if any(self.root.iterdir()):
+                raise ValueError("Refusing to adopt a nonempty cache directory")
+            marker.write_text("local-native-cache-v1\n")
+        if marker.is_symlink() or marker.read_text() != "local-native-cache-v1\n":
+            raise ValueError("Invalid cache ownership marker")
+
+    @contextlib.contextmanager
+    def locked(self):
+        lock = self.root / ".lock"
+        fd = os.open(lock, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+        with os.fdopen(fd, "w") as handle:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            yield
+
+    def entry(self, key):
+        if not re.fullmatch(r"[0-9a-f]{64}", key):
+            raise ValueError("Invalid cache key")
+        result = self.root / key
+        if result.is_symlink():
+            raise ValueError("Cache entry must not be a symlink")
+        return result
+
+    def entries(self):
+        entries = []
+        for item in self.root.iterdir():
+            if item.name in (".lock", ".native-cache-v1"):
+                continue
+            path = self.entry(item.name)
+            if not path.is_dir():
+                raise ValueError("Unexpected cache entry")
+            size = 0
+            for child in path.iterdir():
+                if child.is_symlink() or not child.is_file():
+                    raise ValueError("Unexpected cache payload")
+                size += child.stat().st_size
+            entries.append((item.name, size, item.stat().st_mtime_ns))
+        return entries
+
+    def prune(self, incoming=0, extra_entry=0):
+        entries = self.entries()
+        # Include ownership/lock metadata in the byte limit.
+        available = self.max_bytes - (self.root / ".native-cache-v1").stat().st_size
+        if available <= 0 or incoming > available:
+            return False
+        victims = plan_admission(entries, incoming, available,
+                                 self.max_entries + (1 - extra_entry))
+        if victims is None:
+            return False
+        for key in victims:
+            shutil.rmtree(self.entry(key))
+        return True
+
+    def put(self, key, source):
+        self.entry(key)
+        # Bound archive preparation too: stop writing once the budget is used.
+        with tempfile.TemporaryDirectory(prefix="native-cache-stage-") as tmp:
+            staged = Path(tmp)
+            archive = staged / "artifact.tar"
+            with archive.open("wb") as output:
+                class LimitedWriter:
+                    def write(inner, data):
+                        if output.tell() + len(data) > self.max_bytes:
+                            raise OverflowError("Artifact exceeds cache budget")
+                        return output.write(data)
+                try:
+                    with tarfile.open(fileobj=LimitedWriter(), mode="w|") as tar:
+                        tar.add(source, arcname="payload", recursive=True)
+                except OverflowError:
+                    return False
+            (staged / "metadata.json").write_text(json.dumps({
+                "key": key, "sha256": file_hash(archive)}))
+            size = sum(p.stat().st_size for p in staged.iterdir())
+            with self.locked():
+                if size + (self.root / ".native-cache-v1").stat().st_size > self.max_bytes:
+                    return False
+                existing = self.entry(key)
+                if existing.exists():
+                    shutil.rmtree(existing)
+                if not self.prune(size, 1):
+                    return False
+                existing.mkdir()
+                try:
+                    for path in staged.iterdir():
+                        shutil.copyfile(path, existing / path.name)
+                except BaseException:
+                    shutil.rmtree(existing)
+                    raise
+            return True
+
+    def restore(self, key, destination):
+        destination = Path(destination)
+        if destination.exists() or destination.is_symlink():
+            raise ValueError("Restore destination must not exist")
+        with self.locked():
+            if not self.prune():
+                return False
+            entry = self.entry(key)
+            if not entry.exists():
+                return False
+            try:
+                metadata = json.loads((entry / "metadata.json").read_text())
+                archive = entry / "artifact.tar"
+                if metadata["key"] != key or metadata["sha256"] != file_hash(archive):
+                    return False
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with tempfile.TemporaryDirectory(dir=destination.parent,
+                                                 prefix="native-restore-") as tmp:
+                    with tarfile.open(archive) as tar:
+                        tar.extractall(tmp, filter="data")
+                    os.replace(Path(tmp) / "payload", destination)
+                os.utime(entry, None)
+                return True
+            except (OSError, ValueError, KeyError, tarfile.TarError):
+                return False

--- a/lynxtron_tools/native_cache_budget.py
+++ b/lynxtron_tools/native_cache_budget.py
@@ -1,0 +1,31 @@
+"""Pure admission/eviction planner for a future isolated native cache.
+
+No filesystem writes or Habitat cache eviction. Sizes must include all entry
+files; callers must hold a cache-wide lock through eviction and admission.
+"""
+
+
+def plan_admission(entries, incoming_bytes, max_bytes, max_entries):
+    """Return oldest-first keys to evict, or None for a rejected admission.
+
+    entries: (key, size_bytes, last_access) tuples in this cache's namespace.
+    Incoming staging bytes must also fit: victims are removed before writing.
+    """
+    if max_bytes <= 0 or max_entries <= 0 or incoming_bytes < 0:
+        raise ValueError("Invalid cache budget")
+    if any(size < 0 for _, size, _ in entries):
+        raise ValueError("Invalid entry size")
+    if len({key for key, _, _ in entries}) != len(entries):
+        raise ValueError("Duplicate cache keys")
+    if incoming_bytes > max_bytes:
+        return None
+    remaining = sum(size for _, size, _ in entries)
+    count = len(entries)
+    evicted = []
+    for key, size, _ in sorted(entries, key=lambda item: (item[2], item[0])):
+        if remaining + incoming_bytes <= max_bytes and count + 1 <= max_entries:
+            break
+        evicted.append(key)
+        remaining -= size
+        count -= 1
+    return evicted

--- a/lynxtron_tools/native_fingerprint.py
+++ b/lynxtron_tools/native_fingerprint.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Experimental local Ninja input fingerprint; NOT a cache-hit authorization.
+
+Run after a successful build so compiler-discovered dependencies are available.
+All recorded header dependencies are included conservatively, even for other
+targets. Absolute paths are retained deliberately: cross-workspace reuse is not
+yet supported. Environment/SDK inputs must be supplied explicitly.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shlex
+import subprocess
+
+
+def digest_file(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def fingerprint(build_dir, target, tools, identity, ninja="ninja"):
+    build_dir = Path(build_dir).resolve()
+    if not (build_dir / ".ninja_deps").is_file():
+        raise ValueError("Build first: compiler dependency log is missing")
+
+    def query(*args):
+        return subprocess.check_output(
+            [ninja, "-t", *args], cwd=build_dir, text=True)
+
+    # Ninja shell-quotes input paths; this initial experiment is POSIX-only.
+    inputs = set(shlex.split(query("inputs", target)))
+    generated = {str((build_dir / line.rsplit(": ", 1)[0]).resolve())
+                 for line in query("targets", "all").splitlines()}
+    dependencies = query("deps")
+    if not dependencies.strip() or "(STALE)" in dependencies:
+        raise ValueError("Build first: dependency log is empty or stale")
+    for line in dependencies.splitlines():
+        if line.startswith("    "):
+            inputs.add(line[4:])
+
+    files = {}
+    for value in sorted(inputs):
+        path = Path(value)
+        if not path.is_absolute():
+            path = build_dir / path
+        if str(path.resolve()) in generated:
+            # Hash producer inputs/commands, not outputs requiring compilation.
+            continue
+        if path.is_dir():
+            # CMake emits directory/order-only dependencies. Do not recursively
+            # hash the build directory (it contains outputs and mutable logs).
+            files[str(path)] = {"directory": str(path.resolve())}
+            continue
+        # Preserve the logical path as well as the resolved target identity.
+        files[str(path)] = {
+            "resolved": str(path.resolve(strict=True)),
+            "sha256": digest_file(path),
+        }
+    tool_files = {str(Path(p).resolve(strict=True)): digest_file(Path(p))
+                  for p in tools}
+    if not tool_files or not identity:
+        raise ValueError("Explicit tool files and environment/SDK identity required")
+    manifest = {
+        "schema": 1,
+        "scope": "local-experiment-not-cache-authorization",
+        "target": target,
+        "commands": query("commands", target),
+        "files": files,
+        "tools": tool_files,
+        "identity": identity,
+    }
+    data = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    return {"fingerprint": hashlib.sha256(data.encode()).hexdigest(),
+            "manifest": manifest}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--tool", action="append", required=True)
+    parser.add_argument("--identity", required=True,
+                        help="Explicit SDK/environment identity; not inferred")
+    parser.add_argument("--ninja", default="ninja")
+    args = parser.parse_args()
+    print(json.dumps(fingerprint(args.build_dir, args.target, args.tool,
+                                 args.identity, args.ninja), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/lynxtron_tools/run_local_native_acceptance.sh
+++ b/lynxtron_tools/run_local_native_acceptance.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# All environment preparation and compilation for the local real-build probe.
+set -euo pipefail
+if [[ $# -lt 1 || $# -gt 3 || "$(uname -s)" != Darwin ]]; then
+  echo 'Usage: bash run_local_native_acceptance.sh <isolated-checkout> [lynxtron|cef-webview] [--prepared]' >&2
+  exit 2
+fi
+probe_tools="$(cd "$(dirname "$0")" && pwd)"
+probe_checkout="$(cd "$1" && pwd)"
+probe_component="${2:-lynxtron}"
+case "$probe_component" in lynxtron|cef-webview) ;; *) exit 2 ;; esac
+probe_prepared="${3:-}"
+case "$probe_prepared" in ''|--prepared) ;; *) exit 2 ;; esac
+cd "$probe_checkout"
+if [[ ! -f .native-cache-acceptance-checkout ]]; then
+  echo 'Refusing to prepare a checkout without its acceptance ownership marker' >&2
+  exit 2
+fi
+export GIT_AUTHOR_NAME="Lynxtron cache experiment"
+export GIT_AUTHOR_EMAIL="scripts@lynxtron.com"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+# Existing local Habitat launchers may use python3.9. Expose an already
+# installed interpreter for this process only; never change global pyenv state.
+if command -v pyenv >/dev/null && ! python3.9 --version >/dev/null 2>&1; then
+  if probe_python39="$(pyenv latest 3.9 2>/dev/null)"; then
+    export PYENV_VERSION="$(pyenv version-name):$probe_python39"
+  fi
+fi
+# Only prepare build dependencies. envsetup.sh also rewrites Git hooks; that
+# unrelated side effect is inappropriate for this isolated cache experiment.
+python3 lynxtron_tools/vpython_tools/vpython_env_setup.py --root_dir "$probe_checkout"
+source .venv/bin/activate
+export PATH="$probe_checkout/buildtools/gn:$probe_checkout/buildtools/ninja:$probe_checkout/buildtools/node/bin:$PATH"
+if [[ "$probe_component" == lynxtron && "$probe_prepared" != --prepared ]]; then
+  python3 lynxtron_tools/prepare_build_env.py
+fi
+python3 -m unittest discover -s "$probe_tools" -p 'test_*native*.py'
+python3 "$probe_tools/run_local_native_cache.py" "$probe_checkout" --component "$probe_component"

--- a/lynxtron_tools/run_local_native_cache.py
+++ b/lynxtron_tools/run_local_native_cache.py
@@ -1,0 +1,112 @@
+"""Real local arm64 Lynxtron build/cache round trip, never a CI shortcut.
+
+The first run always compiles. Cache restoration uses a fresh destination and
+does not replace the build output. Full input trees protect absent-header cases.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+from local_native_cache import LocalCache, file_hash, input_key
+
+
+def run(root, component="lynxtron"):
+    if platform.system() != "Darwin":
+        raise RuntimeError("This acceptance runner is macOS-only")
+    root = Path(root).resolve()
+    if not (root / ".native-cache-acceptance-checkout").is_file():
+        raise RuntimeError("Not an isolated acceptance checkout")
+    if shutil.disk_usage(root).free < 25 * 1024**3:
+        raise RuntimeError("Less than 25 GiB free; refusing full native build")
+
+    def command(*args):
+        subprocess.run(args, cwd=root, check=True)
+
+    excluded = [root / "out"]
+    if component == "cef-webview":
+        entry = root / "lynxtron_tools/build_cef_webview.py"
+        if not entry.is_file():
+            raise RuntimeError("CEF acceptance requires the #258 build entry")
+        command(sys.executable, str(entry), "--arch", "arm64")
+        package = root / "src/packages/cef-webview"
+        app = package / "dist/darwin/arm64"
+        excluded.extend([package / "dist", package / "build"])
+    else:
+        command(sys.executable, "lynxtron_tools/gn/gn.py", "--mac-cpu", "arm64")
+        app = root / "out/Release/Lynxtron.app"
+    sdk = subprocess.check_output(["xcrun", "--show-sdk-path"], text=True).strip()
+    # Deliberately broad for the first real acceptance: no source-package
+    # exclusions, inferred external toolchain equivalence, or path rewriting.
+    roots = [p for p in root.iterdir() if p.name not in {
+        ".git", ".venv", "out", ".native-cache-acceptance-checkout"}]
+    roots.append(Path(sdk))
+    roots.append(Path(subprocess.check_output(
+        ["xcrun", "--find", "clang++"], text=True).strip()))
+    identity = {"component": component, "arch": "arm64", "variant": "release", "sdk": sdk,
+                "xcode": subprocess.check_output(["xcodebuild", "-version"],
+                                                  text=True),
+                "environment_digest_only": dict(os.environ)}
+    last_progress = [0.0]
+    def progress(path):
+        if time.monotonic() - last_progress[0] > 10:
+            print(f"Fingerprint scanning: {path}", flush=True)
+            last_progress[0] = time.monotonic()
+    key = input_key(roots, identity, excluded, progress)
+    if component == "lynxtron":
+        command("ninja", "-C", "out/Release", "-j", "4", "lynxtron_app")
+    if not app.is_dir():
+        raise RuntimeError(f"Expected complete native artifact: {app}")
+    if input_key(roots, identity, excluded) != key:
+        raise RuntimeError("Inputs changed during build; refusing cache admission")
+    cache = LocalCache(Path.home() / ".habitat_cache/native-artifacts-v1",
+                       2 * 1024**3, 2)
+    stored = cache.put(key, app)
+    if not stored:
+        raise RuntimeError("App exceeds bounded cache budget; not cached")
+    # Compare every file and symlink of the actual bundle, not just its main exe.
+    def inventory(directory):
+        result = {}
+        for path in directory.rglob("*"):
+            name = str(path.relative_to(directory))
+            if path.is_symlink():
+                result[name] = {"link": os.readlink(path)}
+            elif path.is_file():
+                result[name] = {"sha256": file_hash(path),
+                                "executable": bool(path.stat().st_mode & 0o111)}
+        return result
+
+    with tempfile.TemporaryDirectory(prefix="lynxtron-cache-restore-") as tmp:
+        restored = Path(tmp) / "payload"
+        if not cache.restore(key, restored):
+            raise RuntimeError("Real app cache restore failed")
+        if inventory(app) != inventory(restored):
+            raise RuntimeError("Restored app differs from source build")
+        if component == "cef-webview":
+            executables = [restored / "cef_extension.node"]
+            executables.extend(restored.glob("**/*.app/Contents/MacOS/*"))
+            framework = (restored / "frameworks/Chromium Embedded Framework.framework"
+                         / "Chromium Embedded Framework")
+            executables.append(framework)
+            if len(executables) < 3:
+                raise RuntimeError("CEF helper apps missing from restored payload")
+        else:
+            executables = [restored / "Contents/MacOS/Lynxtron"]
+        for binary in executables:
+            command("lipo", "-verify_arch", "arm64", str(binary))
+    print(json.dumps({"real_app_cache_roundtrip": "pass", "component": component, "key": key,
+                      "max_bytes": cache.max_bytes, "max_entries": 2}))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root")
+    parser.add_argument("--component", choices=["lynxtron", "cef-webview"], default="lynxtron")
+    options = parser.parse_args()
+    run(options.root, options.component)

--- a/lynxtron_tools/test_local_native_cache.py
+++ b/lynxtron_tools/test_local_native_cache.py
@@ -1,0 +1,201 @@
+import concurrent.futures
+import json
+import os
+import random
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from local_native_cache import LocalCache, file_hash, input_key
+
+
+class LocalCacheTest(unittest.TestCase):
+    def test_storage_limits_corruption_and_symlinks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "artifact"
+            source.mkdir()
+            (source / "binary").write_bytes(b"native")
+            (source / "binary").chmod(0o755)
+            (source / "link").symlink_to("binary")
+            cache = LocalCache(root / "cache", 25000, 2)
+            key = "a" * 64
+            self.assertTrue(cache.put(key, source))
+            self.assertTrue(cache.restore(key, root / "restored"))
+            self.assertEqual(os.readlink(root / "restored/link"), "binary")
+            self.assertTrue(os.access(root / "restored/binary", os.X_OK))
+            with self.assertRaises(ValueError):
+                cache.restore(key, source)
+            (cache.entry(key) / "artifact.tar").write_bytes(b"corrupt")
+            self.assertFalse(cache.restore(key, root / "corrupt-restore"))
+            self.assertTrue(cache.put(key, source))
+            (cache.entry(key) / "metadata.json").unlink()
+            self.assertFalse(cache.restore(key, root / "missing-restore"))
+            for index in range(6):
+                self.assertTrue(cache.put(f"{index:064x}", source))
+                self.assertLessEqual(len(cache.entries()), 2)
+                self.assertLessEqual(sum(p.stat().st_size for p in
+                                         cache.root.rglob("*") if p.is_file()), 25000)
+            (source / "huge").write_bytes(b"x" * 30000)
+            self.assertFalse(cache.put("b" * 64, source))
+
+    def test_parallel_writers_and_ownership(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "binary"
+            source.write_bytes(b"native")
+            cache = LocalCache(root / "native", 25000, 2)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+                self.assertTrue(all(pool.map(
+                    lambda n: cache.put(f"{n:064x}", source), range(8))))
+            self.assertLessEqual(len(cache.entries()), 2)
+            with self.assertRaises(ValueError):
+                LocalCache(root, 25000, 2)
+            with self.assertRaises(ValueError):
+                cache.restore("../escape", root / "bad")
+
+    @unittest.skipUnless(shutil.which("ninja") and shutil.which("clang"),
+                         "Ninja/Clang required")
+    def test_real_compilation_mutations(self):
+        with tempfile.TemporaryDirectory(prefix="native-cache-monkey-") as tmp:
+            root = Path(tmp)
+            src = root / "src"
+            src.mkdir()
+            (src / "main.c").write_text(
+                '#include "nested.h"\n'
+                '#if __has_include("optional.h")\n#include "optional.h"\n'
+                '#else\n#define OPTIONAL 0\n#endif\n'
+                'int main(void) { return VALUE + OPTIONAL + FLAG; }\n')
+            (src / "nested.h").write_text('#include "value.h"\n')
+            (src / "value.h").write_text('#define VALUE 1\n')
+            build = root / "build"
+            build.mkdir()
+            compiler = Path(shutil.which("clang"))
+            cache = LocalCache(root / "cache", 1024 * 1024, 3)
+            flags = 0
+            reports = []
+
+            def run_case(name, expected_hit):
+                identity = {"arch": "host", "flags": flags, "sdk": "local"}
+                key = input_key([src, compiler], identity)
+                destination = root / f"restore-{name}"
+                hit = cache.restore(key, destination)
+                self.assertEqual(hit, expected_hit, name)
+                (build / "build.ninja").write_text(
+                    f'rule cc\n  command = {compiler} -DFLAG={flags} '
+                    f'{src / "main.c"} -o $out\n'
+                    f'build probe: cc {src / "main.c"}\n')
+                # Force a genuinely fresh binary for comparison even on hits.
+                (build / "probe").unlink(missing_ok=True)
+                subprocess.run(["ninja", "-C", str(build), "probe"],
+                               check=True, stdout=subprocess.DEVNULL)
+                binary = build / "probe"
+                if hit:
+                    self.assertEqual(file_hash(destination), file_hash(binary), name)
+                    self.assertEqual(subprocess.run([str(destination)]).returncode,
+                                     subprocess.run([str(binary)]).returncode)
+                else:
+                    self.assertTrue(cache.put(key, binary))
+                reports.append({"case": name, "hit": hit})
+
+            run_case("cold", False)
+            run_case("repeat", True)
+            os.utime(src / "main.c", None)
+            run_case("mtime-only", True)
+            (root / "demo.js").write_text("// not a native input\n")
+            run_case("unrelated-js", True)
+            (src / "value.h").write_text('#define VALUE 2\n')
+            run_case("recursive-header", False)
+            (src / "optional.h").write_text('#define OPTIONAL 3\n')
+            run_case("new-optional-header", False)
+            (src / "optional.h").unlink()
+            run_case("remove-optional-header", True)
+            flags = 1
+            run_case("compile-flags", False)
+            # Deterministic monkey cases: each new native value misses, then
+            # an identical rerun hits and is compared with a forced rebuild.
+            for index, value in enumerate(random.Random(259).sample(range(10, 100), 8)):
+                (src / "value.h").write_text(f'#define VALUE {value}\n')
+                run_case(f"monkey-{index}", False)
+                run_case(f"monkey-{index}-repeat", True)
+            before = input_key([src, compiler], {"arch": "arm64"})
+            self.assertNotEqual(before, input_key([src, compiler], {"arch": "x64"}))
+            self.assertNotEqual(before, input_key([src, compiler],
+                                                  {"arch": "arm64", "sdk": "new"}))
+            print(json.dumps({"cache_mutations": reports}))
+
+    def test_tools_generators_and_symlink_inputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            native = root / "native"
+            native.mkdir()
+            tool = root / "compiler"
+            tool.write_text("tool-v1")
+            generator = native / "generate.py"
+            generator.write_text("generator-v1")
+            (native / "input.json").write_text("{}")
+            (native / "header.h").write_text("first")
+            (native / "alias.h").symlink_to("header.h")
+            def key():
+                return input_key([native, tool], {"target": "arm64-release"})
+            previous = key()
+            for path, value in [(tool, "tool-v2"), (generator, "generator-v2"),
+                                (native / "input.json", '{"new":true}'),
+                                (native / "header.h", "second")]:
+                path.write_text(value)
+                current = key()
+                self.assertNotEqual(previous, current)
+                previous = current
+            (native / "alias.h").unlink()
+            (native / "alias.h").symlink_to("missing.h")
+            with self.assertRaises(FileNotFoundError):
+                key()
+
+    def test_escaping_artifact_link_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            source.mkdir()
+            (source / "escape").symlink_to("../../outside")
+            cache = LocalCache(root / "cache", 25000, 2)
+            key = "e" * 64
+            self.assertTrue(cache.put(key, source))
+            self.assertFalse(cache.restore(key, root / "restored"))
+            self.assertFalse((root / "restored").exists())
+
+    def test_cef_payload_layout_and_component_isolation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            payload = root / "cef"
+            framework = payload / "frameworks/Chromium Embedded Framework.framework"
+            version = framework / "Versions/A"
+            (version / "Resources").mkdir(parents=True)
+            (version / "Chromium Embedded Framework").write_bytes(b"framework-fixture")
+            (version / "Resources/icudtl.dat").write_bytes(b"resource-fixture")
+            (framework / "Versions/Current").symlink_to("A")
+            (framework / "Chromium Embedded Framework").symlink_to(
+                "Versions/Current/Chromium Embedded Framework")
+            (framework / "Resources").symlink_to("Versions/Current/Resources")
+            helper = payload / "frameworks/LynxtronWebview.app/Contents/MacOS/LynxtronWebview"
+            helper.parent.mkdir(parents=True)
+            helper.write_bytes(b"helper-fixture")
+            helper.chmod(0o755)
+            (payload / "cef_extension.node").write_bytes(b"addon-fixture")
+            cache = LocalCache(root / "cache", 100000, 2)
+            cef_key = input_key([payload], {"component": "cef-webview", "arch": "arm64"})
+            runtime_key = input_key([payload], {"component": "lynxtron", "arch": "arm64"})
+            self.assertTrue(cache.put(cef_key, payload))
+            self.assertFalse(cache.restore(runtime_key, root / "wrong-component"))
+            self.assertTrue(cache.restore(cef_key, root / "restored"))
+            for source in payload.rglob("*"):
+                restored = root / "restored" / source.relative_to(payload)
+                if source.is_symlink():
+                    self.assertEqual(os.readlink(source), os.readlink(restored))
+                elif source.is_file():
+                    self.assertEqual(file_hash(source), file_hash(restored))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lynxtron_tools/test_native_cache_budget.py
+++ b/lynxtron_tools/test_native_cache_budget.py
@@ -1,0 +1,30 @@
+import unittest
+
+from native_cache_budget import plan_admission
+
+
+class CacheBudgetTest(unittest.TestCase):
+    def test_byte_limit_uses_least_recently_used(self):
+        self.assertEqual(plan_admission(
+            [("recent", 40, 2), ("old", 40, 1)], 50, 100, 10), ["old"])
+
+    def test_entry_count_is_also_bounded(self):
+        self.assertEqual(plan_admission(
+            [("old", 1, 1), ("new", 1, 2)], 1, 100, 2), ["old"])
+
+    def test_oversized_artifact_is_not_cached(self):
+        self.assertIsNone(plan_admission([("keep", 1, 1)], 101, 100, 2))
+
+    def test_repeated_admissions_stay_bounded(self):
+        entries = []
+        for index in range(100):
+            size = index % 20 + 1
+            evictions = plan_admission(entries, size, 50, 4)
+            entries = [entry for entry in entries if entry[0] not in evictions]
+            entries.append((str(index), size, index))
+            self.assertLessEqual(sum(entry[1] for entry in entries), 50)
+            self.assertLessEqual(len(entries), 4)
+
+    def test_invalid_budget_rejected(self):
+        with self.assertRaises(ValueError):
+            plan_admission([], 1, 0, 1)

--- a/lynxtron_tools/test_native_fingerprint.py
+++ b/lynxtron_tools/test_native_fingerprint.py
@@ -56,6 +56,34 @@ class FingerprintTest(unittest.TestCase):
             changed_sdk = fingerprint(build, "probe", [compiler], "other-sdk")
             self.assertNotEqual(flags["fingerprint"], changed_sdk["fingerprint"])
 
+            # A new optional include is absent from the *old* dependency log.
+            # Demonstrate the unsafe hit rather than pretending the graph is
+            # sufficient for cache authorization.
+            (root / "main.c").write_text(
+                '#if __has_include("optional.h")\n#include "optional.h"\n'
+                '#else\n#define OPTIONAL 0\n#endif\n'
+                'int main(void) { return OPTIONAL; }\n')
+            before_optional = compile_and_hash()
+            (root / "optional.h").write_text('#define OPTIONAL 3\n')
+            undiscovered = fingerprint(build, "probe", [compiler], "local-test")
+            self.assertEqual(before_optional, undiscovered,
+                             "Documents the known dependency-discovery hole")
+            # Ninja timestamp checking also cannot detect a formerly absent
+            # header. Force recompilation by changing a tracked source.
+            with (root / "main.c").open("a") as source_file:
+                source_file.write("// force dependency rediscovery\n")
+            discovered = compile_and_hash()
+            self.assertTrue(any(p.endswith("optional.h")
+                                for p in discovered["manifest"]["files"]))
+            self.assertEqual(subprocess.run([str(build / "probe")]).returncode, 3)
+
+            cold = root / "cold-build"
+            subprocess.run(["cmake", "-S", str(root), "-B", str(cold),
+                            "-G", "Ninja", f"-DCMAKE_C_COMPILER={compiler}",
+                            "-DFLAG=1"], check=True, stdout=subprocess.DEVNULL)
+            with self.assertRaisesRegex(ValueError, "Build first"):
+                fingerprint(cold, "probe", [compiler], "local-test")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lynxtron_tools/test_native_fingerprint.py
+++ b/lynxtron_tools/test_native_fingerprint.py
@@ -1,0 +1,61 @@
+"""Real CMake/Ninja local experiment; no mocked build graph."""
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from native_fingerprint import fingerprint
+
+
+@unittest.skipUnless(shutil.which("cmake") and shutil.which("ninja")
+                     and shutil.which("clang"), "CMake/Ninja/Clang required")
+class FingerprintTest(unittest.TestCase):
+    def test_real_build_inputs(self):
+        with tempfile.TemporaryDirectory(prefix="native-fingerprint-") as tmp:
+            root = Path(tmp)
+            build = root / "build"
+            (root / "CMakeLists.txt").write_text(
+                "cmake_minimum_required(VERSION 3.20)\n"
+                "project(fingerprint C)\n"
+                "add_executable(probe main.c)\n"
+                "target_compile_definitions(probe PRIVATE FLAG=${FLAG})\n")
+            (root / "value.h").write_text("#define VALUE 0\n")
+            (root / "main.c").write_text(
+                '#include "value.h"\nint main(void) { return VALUE + FLAG; }\n')
+            compiler = shutil.which("clang")
+
+            def configure(flag):
+                subprocess.run(["cmake", "-S", str(root), "-B", str(build),
+                                "-G", "Ninja", f"-DCMAKE_C_COMPILER={compiler}",
+                                f"-DFLAG={flag}"], check=True,
+                               stdout=subprocess.DEVNULL)
+
+            def compile_and_hash():
+                subprocess.run(["ninja", "-C", str(build), "probe"],
+                               check=True, stdout=subprocess.DEVNULL)
+                return fingerprint(build, "probe", [compiler], "local-test")
+
+            configure(0)
+            with self.assertRaisesRegex(ValueError, "Build first"):
+                fingerprint(build, "probe", [compiler], "local-test")
+            initial = compile_and_hash()
+            self.assertEqual(initial, compile_and_hash())
+            (root / "demo.js").write_text("// unrelated frontend change\n")
+            self.assertEqual(initial, compile_and_hash())
+            (root / "value.h").write_text("#define VALUE 1\n")
+            header = compile_and_hash()
+            self.assertNotEqual(initial["fingerprint"], header["fingerprint"])
+            (root / "main.c").write_text(
+                '#include "value.h"\nint main(void) { return VALUE + FLAG + 1; }\n')
+            source = compile_and_hash()
+            self.assertNotEqual(header["fingerprint"], source["fingerprint"])
+            configure(1)
+            flags = compile_and_hash()
+            self.assertNotEqual(source["fingerprint"], flags["fingerprint"])
+            changed_sdk = fingerprint(build, "probe", [compiler], "other-sdk")
+            self.assertNotEqual(flags["fingerprint"], changed_sdk["fingerprint"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
Local experiment requested during the native build cache discussion. Independent of the CEF/AutoLink alpha. No CI cache activation or workflow changes.

## Implementation
Read Ninja inputs, producer commands and compiler-discovered header dependencies; hash input contents and explicit tool/environment identities. Exclude generated outputs. Emit an auditable JSON manifest.

## Local validation
Real CMake/Ninja/Clang fixture passed: repeat build and unrelated JS retain the fingerprint; C source, header, compile flag and SDK identity changes invalidate it. Missing dependency logs fail closed.

## Not production cache authorization
Warm dependency logs do not establish complete cold-build dependencies or new conditional includes. Absolute paths remain; POSIX-only parsing; SDK/environment closure is explicit and incomplete. No actual Lynxtron/CEF or Habitat artifact-cache acceptance. See lynxtron_tools/NATIVE_FINGERPRINT.md for limits and the command to rerun the experiment.

Please avoid spending full native CI resources on this experiment; existing alpha publishing is unaffected.