### PR TITLE
[BugFix][macOS] Support Xcode 27 SDK headers

### DIFF
--- a/src/build/mac/xcode_27_float_compat/float.h
+++ b/src/build/mac/xcode_27_float_compat/float.h
@@ -1,0 +1,16 @@
+// Copyright 2026 The Lynxtron Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Intentionally no include guard. Xcode 27's <math.h> defines
+// __need_infinity_nan and reincludes <float.h> to request only these macros.
+#if defined(__APPLE__) && defined(CR_XCODE_VERSION) && \
+    CR_XCODE_VERSION >= 2700 && defined(__need_infinity_nan)
+#undef INFINITY
+#undef NAN
+#define INFINITY (__builtin_inff())
+#define NAN (__builtin_nanf(""))
+#undef __need_infinity_nan
+#else
+#include_next <float.h>
+#endif

--- a/src/patches/build/.patches
+++ b/src/patches/build/.patches
@@ -6,3 +6,4 @@ build_change_mac_sdk_min_to_14_from_15.patch
 0003-BugFix-disable-cet.patch
 build_add_lynxtron_size_optimization_defaults.patch
 build_add_linux_warning_config_flags.patch
+build_add_xcode_27_float_header_compatibility_shim.patch

--- a/src/patches/build/build_add_xcode_27_float_header_compatibility_shim.patch
+++ b/src/patches/build/build_add_xcode_27_float_header_compatibility_shim.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shouqun Liu <liushouqun@gmail.com>
+Date: Wed, 9 Sep 2026 01:51:00 -0700
+Subject: [PATCH] [BugFix][macOS] Add Xcode 27 float header compatibility shim
+
+Xcode 27's math.h requests INFINITY and NAN from float.h through the
+__need_infinity_nan protocol. The Clang resource headers bundled by
+Lynxtron predate that protocol, so the macros remain undefined when the
+Xcode 27 SDK is used with Lynxtron's custom libc++. This breaks both
+libc++ compilation and consumers of Metal framework headers.
+
+Add Lynxtron's compatibility include directory before the custom libc++
+headers for C++ and Objective-C++ builds. Its float.h wrapper handles only
+the Xcode 27 protocol request and forwards every normal inclusion to the
+original header with include_next. This leaves the vendored libc++ source
+and non-macOS builds unchanged.
+
+TEST: ninja -C out/Release lynxtron_app
+TEST: Xcode 27 CI-equivalent Release builds for arm64 and x64
+TEST: macOS 26.5 SDK Release build (8454/8454)
+TEST: macOS 26.5 SDK libc++ and Metal regression targets
+
+diff --git a/config/mac/BUILD.gn b/config/mac/BUILD.gn
+index 11e19f2872625b07ae7a16d93b2d83c1c1ca090c..e12ee77c322e1befed086c801d298466b69d2285 100644
+--- a/config/mac/BUILD.gn
++++ b/config/mac/BUILD.gn
+@@ -55,4 +55,10 @@ config("compiler") {
+   asmflags = common_mac_flags
+   cflags = common_mac_flags
+-
++  if (use_custom_libcxx) {
++    xcode_27_float_compat_include =
++        rebase_path("//src/build/mac/xcode_27_float_compat", root_build_dir)
++    cflags_cc = [ "-isystem$xcode_27_float_compat_include" ]
++    cflags_objcc = cflags_cc
++  }
++
+   ldflags = common_mac_flags


### PR DESCRIPTION
## Summary

- add a Lynxtron-owned `float.h` compatibility overlay for Xcode 27
- apply the overlay to macOS C++ and Objective-C++ compilation when using the custom libc++
- keep the vendored libc++ revision and source tree unchanged

## Background

Xcode 27's `math.h` requests `INFINITY` and `NAN` by defining
`__need_infinity_nan` and including `float.h` again. The Chromium Clang
resource headers and libc++ revision currently pinned by Lynxtron predate
that protocol. Because the vendored libc++ `float.h` has a conventional
include guard, the second include can be suppressed and the macros remain
undefined.

This first breaks libc++ compilation in `clamp_to_integral.h`. Fixing only
that call site is insufficient because Xcode's Metal headers also consume
`INFINITY`.

## Fix

Place a narrow compatibility directory before the custom libc++ include
directory for macOS C++ and Objective-C++ builds. Its `float.h` responds only
to the Xcode 27 `__need_infinity_nan` request and forwards all normal includes
to the original header with `include_next`.

This keeps the workaround in Lynxtron's build integration instead of modifying
vendored libc++, does not unconditionally define the macros, and has no effect
on non-Apple builds. The shim can be removed after the pinned Clang/libc++ pair
supports the protocol upstream.

## Verification

- Xcode 27 Release build: `ninja -C out/Release lynxtron_app` (`7230/7230`)
- Xcode 27 libc++ `random_shuffle.o` target
- Xcode 27 Metal `mtl_image_representation.o` target
- macOS 26.5 SDK Release build: `ninja -C out/Release-Xcode26 lynxtron_app` (`8454/8454`)
- macOS 26.5 SDK libc++ `random_shuffle.o` and Metal `mtl_image_representation.o` regression targets
- local `commit-message`, `file-type`, `coding-style`, `copyright`,
  `cpp-header-path`, and `cpplint` checks

The local machine does not have a complete Xcode 26 installation. The 26.5
verification used Lynxtron's bundled Chromium Clang, Xcode 27 host tools, and
the macOS 26.5 SDK. This specifically validates the SDK-header compatibility
boundary affected by this change.
