### PR TITLE
[BugFix][DevPlugins] Fix development startup with selected Rspeedy environments

### DIFF
--- a/.changeset/fix-rspeedy-filtered-dev-urls.md
+++ b/.changeset/fix-rspeedy-filtered-dev-urls.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/lynxtron-dev-plugins': patch
+---
+
+Fix desktop and Web development startup when Rspeedy selects only one of several configured environments. Print URLs from active environments while preserving custom URL printers and disabled URL output.

--- a/src/packages/lynxtron-dev-plugins/README.md
+++ b/src/packages/lynxtron-dev-plugins/README.md
@@ -84,6 +84,10 @@ export default defineConfig({
 });
 ```
 
+The Rspeedy ready plugin also keeps development URL output compatible with
+`--environment`: only active environments are printed when a subset is selected.
+Custom `server.printUrls` callbacks and `server.printUrls: false` are preserved.
+
 ## Rspack Usage
 
 The lower-level Rspack plugin remains available for projects that do not use

--- a/src/packages/lynxtron-dev-plugins/src/rspeedy.ts
+++ b/src/packages/lynxtron-dev-plugins/src/rspeedy.ts
@@ -12,6 +12,92 @@ export function pluginRspeedyDevReady() {
     name: 'dev-ready-rspeedy-plugin',
     apply: 'serve',
     setup(api: any) {
+      api.modifyRsbuildConfig({
+        order: 'post',
+        handler(config: any) {
+          const originalPrintUrls =
+            api.getRsbuildConfig('original').server?.printUrls;
+          const printUrls = config.server?.printUrls;
+          if (
+            originalPrintUrls === false ||
+            typeof originalPrintUrls === 'function' ||
+            typeof printUrls !== 'function'
+          ) {
+            return config;
+          }
+          return {
+            ...config,
+            server: {
+              ...config.server,
+              printUrls(params: any) {
+                const environments = api.getNormalizedConfig().environments;
+                if (
+                  Object.keys(config.environments ?? {}).every(
+                    (name) => name in environments,
+                  )
+                ) {
+                  return printUrls(params);
+                }
+
+                // Rspeedy's URL printer captures all configured environments,
+                // including ones excluded by --environment. Read only the
+                // active normalized configurations when printing instead.
+                const rspeedy = api.useExposed(Symbol.for('rspeedy.api'));
+                if (!rspeedy) return printUrls(params);
+                const filename = rspeedy.config.output?.filename;
+                const bundle =
+                  typeof filename === 'string'
+                    ? filename
+                    : (filename?.bundle ??
+                      filename?.template ??
+                      '[name].[platform].bundle');
+                return Object.entries(environments).flatMap(
+                  ([name, environment]: [string, any]) => {
+                    const host = environment.dev.client?.host ?? 'localhost';
+                    const prefix = environment.dev.assetPrefix;
+                    const base = (
+                      typeof prefix === 'string'
+                        ? prefix
+                        : `http://${host}:<port>/`
+                    ).replaceAll('<port>', String(params.port));
+                    return Object.keys(environment.source.entry).flatMap(
+                      (entryName) => {
+                        const template =
+                          typeof bundle === 'function'
+                            ? bundle({
+                                entryName,
+                                platform: name,
+                                lazyBundle: false,
+                              })
+                            : bundle;
+                        const pathname = template
+                          .replaceAll('[name]', entryName)
+                          .replaceAll('[platform]', name);
+                        const urls = [
+                          {
+                            label: name.charAt(0).toUpperCase() + name.slice(1),
+                            url: new URL(pathname, base).toString(),
+                          },
+                        ];
+                        if (name === 'web') {
+                          urls.push({
+                            label: '∟ Preview',
+                            url: new URL(
+                              `/__web_preview?casename=${encodeURIComponent(pathname)}`,
+                              base,
+                            ).toString(),
+                          });
+                        }
+                        return urls;
+                      },
+                    );
+                  },
+                );
+              },
+            },
+          };
+        },
+      });
       let done = false;
       api.onAfterStartDevServer((params: any) => {
         const port = params && params.port;
@@ -32,7 +118,7 @@ export function pluginRspeedyDevReady() {
                 ready: true,
                 source: 'rspeedy',
                 time: Date.now(),
-              })
+              }),
             );
           } catch {}
         }

--- a/src/packages/lynxtron-dev-plugins/test/rspeedy.test.js
+++ b/src/packages/lynxtron-dev-plugins/test/rspeedy.test.js
@@ -1,0 +1,117 @@
+// Copyright 2026 The Lynxtron Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRsbuild } from '@rsbuild/core';
+import { pluginRspeedyDevReady } from '../dist/rspeedy.js';
+
+async function printer({ selected, filename, custom, pluginFirst = false }) {
+  let api;
+  let upstreamCalls = 0;
+  // Reproduce the released Lynx plugin's capture of unfiltered environments.
+  const upstream = {
+    name: 'test-rspeedy-url-printer',
+    setup(pluginApi) {
+      api = pluginApi;
+      api.expose(Symbol.for('rspeedy.api'), {
+        config: { output: { filename } },
+      });
+      api.modifyRsbuildConfig((config) => {
+        if (
+          config.server.printUrls !== undefined &&
+          config.server.printUrls !== true
+        ) {
+          return config;
+        }
+        const names = Object.keys(config.environments);
+        config.server.printUrls = () => {
+          upstreamCalls++;
+          for (const environment of names)
+            api.getNormalizedConfig({ environment });
+          return [{ label: 'Original', url: 'https://original.example/' }];
+        };
+        return config;
+      });
+    },
+  };
+  const plugins = [upstream, pluginRspeedyDevReady()];
+  const rsbuild = await createRsbuild({
+    environment: selected,
+    rsbuildConfig: {
+      server: { printUrls: custom },
+      source: { entry: { main: import.meta.filename } },
+      environments: {
+        web: {},
+        lynx: {},
+      },
+      dev: { assetPrefix: 'https://localhost:<port>/bundles/' },
+      plugins: pluginFirst ? plugins.reverse() : plugins,
+    },
+  });
+  await rsbuild.initConfigs();
+  return {
+    print: api.getNormalizedConfig().server.printUrls,
+    upstreamCalls: () => upstreamCalls,
+  };
+}
+
+test('desktop-only URLs exclude web regardless of plugin registration order', async () => {
+  for (const pluginFirst of [false, true]) {
+    const result = await printer({ selected: ['lynx'], pluginFirst });
+    assert.deepEqual(result.print({ port: 5969, routes: [] }), [
+      { label: 'Lynx', url: 'https://localhost:5969/bundles/main.lynx.bundle' },
+    ]);
+    assert.equal(result.upstreamCalls(), 0);
+  }
+});
+
+test('web-only URLs preserve custom bundle names and browser preview', async () => {
+  const { print } = await printer({
+    selected: ['web'],
+    filename: {
+      bundle: ({ entryName, platform, lazyBundle }) => {
+        assert.equal(lazyBundle, false);
+        return `custom/${entryName}.${platform}.bundle`;
+      },
+    },
+  });
+  assert.deepEqual(print({ port: 6000, routes: [] }), [
+    {
+      label: 'Web',
+      url: 'https://localhost:6000/bundles/custom/main.web.bundle',
+    },
+    {
+      label: '∟ Preview',
+      url: 'https://localhost:6000/__web_preview?casename=custom%2Fmain.web.bundle',
+    },
+  ]);
+});
+
+test('string filenames retain entry and platform substitutions', async () => {
+  const { print } = await printer({
+    selected: ['lynx'],
+    filename: 'app/[name]-[platform].bundle',
+  });
+  assert.equal(
+    print({ port: 5969, routes: [] })[0].url,
+    'https://localhost:5969/bundles/app/main-lynx.bundle',
+  );
+});
+
+test('unfiltered development retains the upstream printer', async () => {
+  const result = await printer({ selected: ['web', 'lynx'] });
+  assert.deepEqual(result.print({ port: 5969, routes: [] }), [
+    { label: 'Original', url: 'https://original.example/' },
+  ]);
+  assert.equal(result.upstreamCalls(), 1);
+});
+
+test('custom URL callbacks and disabled output are untouched', async () => {
+  const custom = () => [{ label: 'Custom', url: 'https://custom.example/' }];
+  for (const setting of [custom, false]) {
+    const { print } = await printer({ selected: ['lynx'], custom: setting });
+    assert.equal(print, setting);
+  }
+});


### PR DESCRIPTION
The default create-lynxtron app declares both `lynx` and `web`, but `npm run dev` selects only `lynx`. With the published `@lynx-js/rsbuild-plugin@0.1.1`, the URL printer still queries the normalized `web` configuration and aborts startup with `Cannot find normalized config by environment: web`. Selecting only `web` has the symmetric failure.

Add a compatibility fix to `pluginRspeedyDevReady()` in Lynxtron: after upstream config hooks run, print URLs from active normalized environments when a subset is selected. Preserve bundle filename customization, asset prefixes, Web preview URLs, user-provided `printUrls` callbacks, disabled printing, and upstream behavior when all environments are active. Include a patch changeset.

Validation:
- All 29 dev-plugin tests pass. New regression tests exercise real Rsbuild environment normalization and both plugin registration orders.
- Against the pre-fix plugin, three new regression cases reproduce the missing-environment errors.
- In a copy of the fresh alpha consumer (Rspeedy 0.17.1 / plugin 0.1.1), replacing only this plugin module makes `npm run dev` compile and launch the desktop CEF page, including its DOM/animation-frame callback.
- `npm run dev:web` compiles, prints the Web bundle/preview URLs, and serves the host page successfully.
- Formatting and `git diff --check` pass.

Consumer smoke checks ran on Windows. This PR only addresses development startup; it does not address the separate macOS CI CEF rendering observation or signing.