### PR TITLE
[BugFix] Report CEF WebView initialization failures

### DIFF
--- a/.changeset/cef-init-error.md
+++ b/.changeset/cef-init-error.md
@@ -1,0 +1,6 @@
+---
+'@lynx-js/cef-webview': patch
+---
+
+Throw an actionable error when native CEF initialization fails and document the
+current single-browser-host-process limitation across applications.

--- a/src/packages/cef-webview/README.md
+++ b/src/packages/cef-webview/README.md
@@ -34,10 +34,21 @@ import cefWebview from '@lynx-js/cef-webview/lynxtron';
 cefWebview.initialize();
 ```
 
-Once initialized, you can use the `<webview>` element in your Lynx templates:
+`initialize()` throws if native CEF initialization returns `false`. Do not
+continue creating WebViews after this error. The current implementation shares
+the default CEF storage directory across host applications, so only one host
+process can initialize the CEF browser at a time. That process can create multiple
+WebViews; CEF helper subprocesses are not additional browser host processes.
+Close other applications running WebView and retry. This is not the only possible
+cause of initialization failure; check the native logs for the actual cause.
 
-```xml
-<webview src="https://www.example.com" width="100%" height="500px"></webview>
+Once initialized, you can use the `<webview>` element in your ReactLynx components:
+
+```tsx
+<webview
+  src="https://www.example.com"
+  style={{ width: '100%', height: '500px' }}
+/>
 ```
 
 ## Building

--- a/src/packages/cef-webview/index.cjs
+++ b/src/packages/cef-webview/index.cjs
@@ -39,7 +39,20 @@ if (!nativeBinding) {
 }
 
 function initialize(options = {}) {
-  return nativeBinding.initialize(options);
+  // The current implementation shares the default CEF storage directory across
+  // host applications. Only one host process can initialize the CEF browser at
+  // a time; that process can create multiple WebViews. CEF helper subprocesses
+  // are not additional browser host processes.
+  const result = nativeBinding.initialize(options);
+  if (result === false) {
+    throw new Error(
+      'CEF initialization failed. The current version does not support ' +
+        'multiple host processes using WebView at the same time. ' +
+        'Close other applications running WebView and try again. ' +
+        'Initialization can also fail for other reasons; check the native logs.'
+    );
+  }
+  return result;
 }
 
 const cefWebview = {

--- a/src/packages/cef-webview/index.d.cts
+++ b/src/packages/cef-webview/index.d.cts
@@ -1,0 +1,19 @@
+/** CEF-backed WebViews for Lynxtron applications. */
+declare namespace cefWebview {
+  /**
+   * Initializes CEF before creating WebViews.
+   *
+   * The current implementation shares the default CEF storage directory across
+   * host applications. Only one host process can initialize the CEF browser at
+   * a time. That process can create multiple WebViews; CEF helper subprocesses
+   * are not additional browser host processes.
+   *
+   * @returns `true` when native initialization succeeds.
+   * @throws If native initialization fails. Do not continue creating WebViews.
+   * Close other applications running WebView and retry. Initialization can also
+   * fail for other reasons; check the native logs for the actual cause.
+   */
+  function initialize(): boolean;
+}
+
+export = cefWebview;

--- a/src/packages/cef-webview/package.json
+++ b/src/packages/cef-webview/package.json
@@ -9,9 +9,16 @@
     "url": "https://github.com/lynx-family/lynxtron.git"
   },
   "main": "index.cjs",
+  "types": "index.d.cts",
   "exports": {
-    ".": "./index.cjs",
-    "./lynxtron": "./index.cjs",
+    ".": {
+      "types": "./index.d.cts",
+      "default": "./index.cjs"
+    },
+    "./lynxtron": {
+      "types": "./index.d.cts",
+      "default": "./index.cjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -26,6 +33,7 @@
   ],
   "files": [
     "index.cjs",
+    "index.d.cts",
     "lynx.lib.json",
     "README.md",
     "dist/**/*",

--- a/src/packages/cef-webview/test/index.test.js
+++ b/src/packages/cef-webview/test/index.test.js
@@ -19,7 +19,7 @@ const manifest = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../lynx.lib.json'), 'utf8')
 );
 
-function loadEntry({ platform, arch, manifest }) {
+function loadEntry({ platform, arch, manifest, initialize }) {
   const module = { exports: {} };
   const loadedPaths = [];
   const context = {
@@ -37,6 +37,7 @@ function loadEntry({ platform, arch, manifest }) {
       loadedPaths.push(specifier);
       return {
         initialize(options) {
+          if (initialize) return initialize(options);
           return { options, platform, arch };
         },
       };
@@ -45,6 +46,47 @@ function loadEntry({ platform, arch, manifest }) {
 
   vm.runInNewContext(entrySource, context, { filename: 'index.cjs' });
   return { entry: module.exports, loadedPaths, process: context.process };
+}
+
+for (const [platform, arch] of [
+  ['darwin', 'arm64'],
+  ['win32', 'x64'],
+]) {
+  test(`${platform}: reports native initialization failure with actionable guidance`, () => {
+    const { entry } = loadEntry({
+      platform,
+      arch,
+      manifest,
+      initialize: () => false,
+    });
+    assert.throws(() => entry.initialize(), {
+      message:
+        /CEF initialization failed.*multiple host processes.*Close other applications.*other reasons.*native logs/,
+    });
+  });
+
+  test(`${platform}: preserves successful initialization and native exceptions`, () => {
+    const options = { cachePath: 'cache' };
+    const failure = new Error('native failure');
+    let calls = 0;
+    const { entry } = loadEntry({
+      platform,
+      arch,
+      manifest,
+      initialize(value) {
+        assert.equal(value, options);
+        if (++calls === 3) throw failure;
+        return true;
+      },
+    });
+    assert.equal(entry.initialize(options), true);
+    assert.equal(entry.initialize(options), true);
+    assert.throws(
+      () => entry.initialize(options),
+      (error) => error === failure
+    );
+    assert.equal(calls, 3);
+  });
 }
 
 test('loads the Windows x64 binary selected by lynx.lib.json', () => {
@@ -127,10 +169,7 @@ test('macOS metadata publishes the package-owned CEF bundles', () => {
     'dist/darwin/arm64/frameworks/LynxtronWebview Helper (Plugin).app',
     'dist/darwin/arm64/frameworks/LynxtronWebview Helper (Renderer).app',
   ]);
-  assert.match(
-    cmakeSource,
-    /set\(CEF_WEBVIEW_HELPER_NAME "LynxtronWebview"\)/
-  );
+  assert.match(cmakeSource, /set\(CEF_WEBVIEW_HELPER_NAME "LynxtronWebview"\)/);
   assert.match(
     cmakeSource,
     /set\(CEF_WEBVIEW_HELPER_BUNDLE_ID "org\.lynxjs\.lynxtron\.webview\.helper"\)/

--- a/src/packages/cef-webview/test/types.cts
+++ b/src/packages/cef-webview/test/types.cts
@@ -1,0 +1,6 @@
+import webview = require('@lynx-js/cef-webview');
+import autolinkWebview = require('@lynx-js/cef-webview/lynxtron');
+
+const initialized: boolean = webview.initialize();
+const autolinkInitialized: boolean = autolinkWebview.initialize();
+void [initialized, autolinkInitialized];

--- a/src/packages/cef-webview/test/types.mts
+++ b/src/packages/cef-webview/test/types.mts
@@ -1,0 +1,10 @@
+import webview from '@lynx-js/cef-webview';
+import autolinkWebview from '@lynx-js/cef-webview/lynxtron';
+
+const initialized: boolean = webview.initialize();
+const autolinkInitialized: boolean = autolinkWebview.initialize();
+void [initialized, autolinkInitialized];
+
+// @ts-expect-error Initialization does not return a string.
+const invalid: string = webview.initialize();
+void invalid;


### PR DESCRIPTION
## Summary

- Throw an actionable JavaScript error when native CEF initialization returns `false`, instead of letting callers proceed silently to a blank WebView.
- Add English comments and documentation explaining the current limitation: host applications share the default CEF storage directory, so only one browser host process can initialize at a time. Multiple WebViews within that process and CEF helper subprocesses are allowed.
- Preserve successful return values and native exceptions; do not assert that every initialization failure is a process conflict.
- Include a patch changeset for `@lynx-js/cef-webview`.

## Validation

`node --test src/packages/cef-webview/test/*.test.js`: 19 passing.
Tests mock the native binding for both macOS and Windows selection paths and cover false returns, successful/repeated calls, option forwarding, and native exceptions.

Formatting and `git diff --check` pass. This is a JS-only change; no native rebuild or GUI acceptance is claimed.

## Scope

No Bundle ID/profile isolation, cross-process lock, or native message-pump cleanup changes. Native crash handling after failed initialization remains separate; throwing here does not fix it.
